### PR TITLE
UpdateDetails no longer throws exception when updating person

### DIFF
--- a/crisischeckin/Services.UnitTest/VolunteerServiceTest.cs
+++ b/crisischeckin/Services.UnitTest/VolunteerServiceTest.cs
@@ -222,6 +222,36 @@ namespace Services.UnitTest
         }
 
         [TestMethod]
+        public void UpdateDetails_ChangeEmailToUnusuedEmail_DoesNotThrowPersonEmailAlreadyInUseException()
+        {
+            Person moqPersonOne = new Person()
+            {
+                Id = 1,
+                UserId = null,
+                FirstName = "Cathy",
+                LastName = "Jones",
+                Email = "cathy.jones@email.com",
+                PhoneNumber = "555-222-9139"
+            };
+
+            List<Person> people = new List<Person>();
+            people.Add(moqPersonOne);
+
+            var moqDataService = new Mock<IDataService>();
+            moqDataService.Setup(s => s.Persons).Returns(people.AsQueryable());
+
+            VolunteerService service = new VolunteerService(moqDataService.Object);
+            // Try to change Cathy Jones' email to something not in use...
+            service.UpdateDetails(new Person()
+            {
+                Id = 1,
+                Email = "unused@email.com",
+                FirstName = "Cathy",
+                LastName = "Jones"
+            });
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void UpdateDetails_NullPerson()
         {

--- a/crisischeckin/Services/VolunteerService.cs
+++ b/crisischeckin/Services/VolunteerService.cs
@@ -59,9 +59,9 @@ namespace Services
                 if (foundPerson.Email != updatedPerson.Email)
                 {
                     // check that new email isn't already in use
-                    var u = ourService.Persons.Any(p => p.Email == updatedPerson.Email);
+                    bool emailIsInUse = ourService.Persons.Any(p => p.Email == updatedPerson.Email);
 
-                    if (u != null)
+                    if (emailIsInUse)
                     {
                         throw new PersonEmailAlreadyInUseException();
                     }


### PR DESCRIPTION
Fixes #109.  UpdateDetails was always throwing a PersonEmailAlreadyInUseException if a person was found.
