### PR TITLE
Issue 27, Password length error message displays lower and upper bounds ...

### DIFF
--- a/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
@@ -33,7 +33,7 @@ namespace crisicheckinweb.ViewModels
         public string UserName { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be between {2} and {1} characters long.", MinimumLength = 6)]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
         public string Password { get; set; }


### PR DESCRIPTION
Fixed issue 27, now when using a string shorter than 6 or longer than 100 characters for password, the error message displayed is "The password must be between 6 and 100 characters long."
