### PR TITLE
Fixed: Admin account was losing admin links on some pages

### DIFF
--- a/crisischeckin/crisicheckinweb/Controllers/AccountController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/AccountController.cs
@@ -115,7 +115,7 @@ namespace crisicheckinweb.Controllers
 
         public ActionResult ChangePassword()
         {
-            return View();
+            return View("ChangePassword", DetermineLayout(), null);
         }
 
         [HttpPost]
@@ -130,7 +130,7 @@ namespace crisicheckinweb.Controllers
                 }
                 ModelState.AddModelError("OldPassword", "Old password is not correct.");
             }
-            return View();
+            return View("ChangePassword", DetermineLayout(), null);
         }
 
         public ActionResult PasswordChanged()
@@ -147,7 +147,7 @@ namespace crisicheckinweb.Controllers
                 return View(model);
             }
 
-            return View();
+            return View("ChangeContactInfo", DetermineLayout(), null);
         }
 
         [HttpPost]
@@ -175,7 +175,7 @@ namespace crisicheckinweb.Controllers
                     ModelState.AddModelError("Email", "This Email Address is already in use!");
                 }
             }
-            return View();
+            return View("ChangeContactInfo", DetermineLayout(), model);
         }
 
         public ActionResult ContactInfoChanged()
@@ -232,6 +232,14 @@ namespace crisicheckinweb.Controllers
             {
                 return RedirectToAction("Index", "Home");
             }
+        }
+
+        private string DetermineLayout()
+        {
+            if (!User.IsInRole(Constants.RoleAdmin))
+                return "~/Views/Shared/_VolunteerLayout.cshtml";
+            else
+                return "~/Views/Shared/_AdminLayout.cshtml";
         }
 
         public enum ManageMessageId

--- a/crisischeckin/crisicheckinweb/Views/Account/ChangeContactInfo.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Account/ChangeContactInfo.cshtml
@@ -1,14 +1,13 @@
 ﻿@model crisicheckinweb.ViewModels.ChangeContactInfoViewModel
 @{
     ViewBag.Title = "ChangeContactInfo";
-    Layout = "~/Views/Shared/_VolunteerLayout.cshtml";
 }
 
 <h2>Change Contact Info</h2>
 
 @using (Html.BeginForm("ChangeContactInfo", "Account", FormMethod.Post))
 {
-    if (!User.IsInRole(Common.Constants.RoleAdmin)) { 
+    if(@Model != null) {
     <div class="row">
         <div class="col-3">
             @Html.LabelFor(m => m.Email)

--- a/crisischeckin/crisicheckinweb/Views/Account/PasswordChanged.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Account/PasswordChanged.cshtml
@@ -1,5 +1,9 @@
 ﻿@{
     ViewBag.Title = "PasswordChanged";
+    if (User.IsInRole(Common.Constants.RoleAdmin))
+    { 
+        Layout = "~/Views/Shared/_AdminLayout.cshtml";
+    }
 }
 
 <h2>Password Changed</h2>


### PR DESCRIPTION
While logged in as admin and changing a password or contact info, pages used _VolunteerLayout.cshtml. This fix dynamically determines the layout based on the user's role.

I don't believe this is an open issue, but I still fixed it.
