### PR TITLE
Issue #224 - Updated behaviour inline with VolunteerService

### DIFF
--- a/crisischeckin/Models/Disaster.cs
+++ b/crisischeckin/Models/Disaster.cs
@@ -1,9 +1,12 @@
-﻿namespace Models
+﻿using System.ComponentModel;
+namespace Models
 {
     public class Disaster
     {
         public int Id { get; set; }
         public string Name { get; set; }
+
+        [DisplayName("Is Currently Active?")]
         public bool IsActive { get; set; }
     }
 }

--- a/crisischeckin/Services.UnitTest/DisasterServiceTest.cs
+++ b/crisischeckin/Services.UnitTest/DisasterServiceTest.cs
@@ -336,7 +336,7 @@ namespace Services.UnitTest
 
         [TestMethod]
         [ExpectedException(typeof(Services.Exceptions.DisasterAlreadyExistsException))]
-        public void UpdateDisaster_SameName_ThrowDisasterAlreadyExistsException()
+        public void CreateDisaster_SameName_ThrowDisasterAlreadyExistsException()
         {
             // arrange
             var dataList = new List<Disaster>{
@@ -428,7 +428,79 @@ namespace Services.UnitTest
             Assert.AreEqual(null, result);
         }
 
+        [TestMethod]
+        public void UpdateDisaster_Valid()
+        {
+            // arrange
+            var dataList = new List<Disaster>{
+                new Disaster {Id= 1, Name = "name", IsActive = true },
+                new Disaster {Id = 2, Name = "name2", IsActive = true }
+            }.AsQueryable();
 
+            _mockDataService.Setup(m => m.Disasters).Returns(dataList);
+
+            Disaster updatedDisasterResult = null;
+            _mockDataService.Setup(m => m.UpdateDisaster(It.IsAny<Disaster>())).Callback<Disaster>(d => updatedDisasterResult = d);
+
+            var updatedDisaster = new Disaster { Id = 1, Name = "name", IsActive = false };
+
+            // act
+            _disasterService.Update(updatedDisaster);
+
+            // assert
+            Assert.AreEqual(updatedDisaster.Name, updatedDisasterResult.Name);
+            Assert.AreEqual(updatedDisaster.IsActive, updatedDisasterResult.IsActive);
+            _mockDataService.Verify(m => m.UpdateDisaster(updatedDisaster));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(Services.Exceptions.DisasterAlreadyExistsException))]
+        public void UpdateDisaster_SameName_ThrowsDisasterAlreadyExistsException()
+        {
+            // arrange
+            var dataList = new List<Disaster>{
+                new Disaster {Id= 1, Name = "name", IsActive = true },
+                new Disaster {Id = 2, Name = "name2", IsActive = true }
+            }.AsQueryable();
+
+            _mockDataService.Setup(m => m.Disasters).Returns(dataList);
+
+            Disaster updatedDisasterResult = null;
+            _mockDataService.Setup(m => m.UpdateDisaster(It.IsAny<Disaster>())).Callback<Disaster>(d => updatedDisasterResult = d);
+
+            var updatedDisaster = new Disaster { Id = 2, Name = "name", IsActive = true };
+
+            // act
+            _disasterService.Update(updatedDisaster);
+
+            // assert
+            // Should throw a DisasterAlreadyExistsException
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(Services.Exceptions.DisasterNotFoundException))]
+        public void UpdateDisaster_InvalidId_ThrowsDisasterNotFoundException()
+        {
+            // arrange
+            var dataList = new List<Disaster>{
+                new Disaster {Id= 1, Name = "name", IsActive = true },
+                new Disaster {Id = 2, Name = "name2", IsActive = true }
+            }.AsQueryable();
+
+            _mockDataService.Setup(m => m.Disasters).Returns(dataList);
+
+            Disaster updatedDisasterResult = null;
+            _mockDataService.Setup(m => m.UpdateDisaster(It.IsAny<Disaster>())).Callback<Disaster>(d => updatedDisasterResult = d);
+
+            var updatedDisaster = new Disaster { Id = 5, Name = "name", IsActive = true };
+
+            // act
+            _disasterService.Update(updatedDisaster);
+
+            // assert
+            // Should throw a DisasterNotFoundException
+        }
+        
         private void InitializeDisasterCollection(params Disaster[] disasters)
         {
             _mockDataService.Setup(ds => ds.Disasters).Returns(disasters.AsQueryable());

--- a/crisischeckin/Services/DataService.cs
+++ b/crisischeckin/Services/DataService.cs
@@ -96,6 +96,21 @@ namespace Services
             context.SaveChanges();
         }
 
+        public Disaster UpdateDisaster(Disaster updatedDisaster)
+        {
+            var result = context.Disasters.Find(updatedDisaster.Id);
+
+            if (result == null)
+                throw new DisasterNotFoundException();
+
+            result.Name = updatedDisaster.Name;
+            result.IsActive = updatedDisaster.IsActive;
+
+            context.SaveChanges();
+
+            return result;
+        }
+
         public void SubmitChanges()
         {
             context.SaveChanges();

--- a/crisischeckin/Services/DisasterService.cs
+++ b/crisischeckin/Services/DisasterService.cs
@@ -75,18 +75,18 @@ namespace Services
             _dataService.RemoveCommitmentById(commitmentId);
         }
 
-        public void Update(int disasterId, string disasterName, bool isActive)
+        public Disaster Update(Disaster updatedDisaster)
         {
 
-            if (_dataService.Disasters.Any(d => d.Name == disasterName)) throw new DisasterAlreadyExistsException();
+            if (_dataService.Disasters.Count(d => d.Id == updatedDisaster.Id) == 0)
+                throw new DisasterNotFoundException();
 
-            var origDisaster = _dataService.Disasters.SingleOrDefault(d => d.Id.Equals(disasterId));
+            if (_dataService.Disasters.Any(d => d.Name == updatedDisaster.Name && d.Id != updatedDisaster.Id)) 
+                throw new DisasterAlreadyExistsException();
 
-            if (origDisaster == null) return;
-            origDisaster.Name = disasterName;
-            origDisaster.IsActive = isActive;
+            var result = _dataService.UpdateDisaster(updatedDisaster);
 
-            _dataService.SubmitChanges();
+            return result;
         }
 
         public IEnumerable<Disaster> GetActiveList()

--- a/crisischeckin/Services/Exceptions/DisasterNotFoundException.cs
+++ b/crisischeckin/Services/Exceptions/DisasterNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Services.Exceptions
+{
+    public class DisasterNotFoundException : Exception
+    {
+    }
+}

--- a/crisischeckin/Services/Interfaces/IDataService.cs
+++ b/crisischeckin/Services/Interfaces/IDataService.cs
@@ -20,6 +20,7 @@ namespace Services.Interfaces
         void AddCommitment(Commitment newCommitment);
         void RemoveCommitmentById(int id);
         void AddDisaster(Disaster newDisaster);
+        Disaster UpdateDisaster(Disaster updatedDisaster);
         void SubmitChanges();
         ClusterCoordinator AddClusterCoordinator(ClusterCoordinator clusterCoordinator);
         void AppendClusterCoordinatorLogEntry(ClusterCoordinatorLogEntry clusterCoordinatorLogEntry);

--- a/crisischeckin/Services/Interfaces/IDisaster.cs
+++ b/crisischeckin/Services/Interfaces/IDisaster.cs
@@ -13,7 +13,7 @@ namespace Services.Interfaces
         void RemoveCommitmentById(int commitmentId);
         Disaster Get(int disasterId);
         void Create(Disaster disaster);
-        void Update(int disasterId, string disasterName, bool isActive);
+        Disaster Update(Disaster updatedDisaster);
         IEnumerable<Disaster> GetActiveList();
         IEnumerable<Disaster> GetList();
         string GetName(int disasterId);

--- a/crisischeckin/Services/Services.csproj
+++ b/crisischeckin/Services/Services.csproj
@@ -61,6 +61,7 @@
     <Compile Include="DebugMessageSender.cs" />
     <Compile Include="DisasterService.cs" />
     <Compile Include="Exceptions\DisasterAlreadyExistsException.cs" />
+    <Compile Include="Exceptions\DisasterNotFoundException.cs" />
     <Compile Include="Exceptions\PersonAlreadyExistsException.cs" />
     <Compile Include="Exceptions\PersonNotFoundException.cs" />
     <Compile Include="Interfaces\IMessageCoordinator.cs" />

--- a/crisischeckin/crisicheckinweb/Controllers/DisasterController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/DisasterController.cs
@@ -58,7 +58,7 @@ namespace crisicheckinweb.Controllers
                 {
                     try
                     {
-                        _disasterSvc.Update(disaster.Id, disaster.Name, disaster.IsActive);
+                        _disasterSvc.Update(disaster);
                     }
                     catch (DisasterAlreadyExistsException)
                     {
@@ -95,7 +95,7 @@ namespace crisicheckinweb.Controllers
                 }
                 else
                 {
-                    _disasterSvc.Update(disaster.Id, disaster.Name, disaster.IsActive);
+                    _disasterSvc.Update(disaster);
                 }
 
                 return Redirect("/Disaster/List");

--- a/crisischeckin/crisicheckinweb/Views/Disaster/Create.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Disaster/Create.cshtml
@@ -10,16 +10,16 @@
     <fieldset>
         <legend>Create / Edit Disaster</legend>
         @Html.ValidationSummary()
-        <ol>
+        <ul>
             <li>
                 @Html.LabelFor(m => m.Name)
                 @Html.TextBoxFor(m => m.Name)
             </li>
             <li>
-                Is Currently Active?
+                @Html.LabelFor(m => m.IsActive)
                 @Html.CheckBoxFor(m => m.IsActive)
             </li>
-        </ol>
-        <input type="submit" value="Create" class="btn btn-success" />
+        </ul>
+        <input type="submit" value="@(Model.Id > 0 ? "Update" : "Create")" class="btn btn-success" />
     </fieldset>
 }


### PR DESCRIPTION
Actual data update performed by DataService. Update method check for duplicate disaster name refined and  now returns the updated object with exceptions thrown as appropriate.

Unit tests added for valid and invalid operations