### PR TITLE
Allow emails to be sent only to cluster coordinators

### DIFF
--- a/crisischeckin/Services.UnitTest/AdminServiceTests.cs
+++ b/crisischeckin/Services.UnitTest/AdminServiceTests.cs
@@ -204,6 +204,37 @@ namespace Services.UnitTest
         }
 
         [TestMethod]
+        public void GetVolunteersByDate_FiltersToOnlyClusterCoordinators()
+        {
+            var otherCommitment = new Commitment
+            {
+                DisasterId = disasterWithCommitments.Id,
+                PersonId = personWithNoCommitmentsID,
+                Id = 102,
+                StartDate = new DateTime(2013, 8, 10),
+                EndDate = new DateTime(2013, 8, 15)
+            };
+
+            var clusterCoordinator = new ClusterCoordinator
+            {
+                Id = 1001,
+                DisasterId = disasterWithCommitments.Id,
+                PersonId = personWithCommitmentsID,
+            };
+
+            initializeDisasterCollection(disasterWithCommitments);
+            initializeVolunteerCollection(personWithCommitments, personWithNoCommitments);
+            initializeCommitmentCollection(commitment, otherCommitment);
+            mockService.Setup(ds => ds.ClusterCoordinators).Returns(new[] { clusterCoordinator }.AsQueryable());
+
+            var underTest = new AdminService(mockService.Object);
+
+            var result = underTest.GetVolunteersForDate(disasterWithCommitments, new DateTime(2013, 08, 12), clusterCoordinatorsOnly: true);
+
+            Assert.AreEqual(1, result.Count());
+        }
+
+        [TestMethod]
         public void WhenOneVolunteerHasRegisteredReturnNoRecordsInRange()
         {
             initializeDisasterCollection(disasterWithCommitments);

--- a/crisischeckin/Services.UnitTest/AdminServiceTests.cs
+++ b/crisischeckin/Services.UnitTest/AdminServiceTests.cs
@@ -198,7 +198,7 @@ namespace Services.UnitTest
 
             var underTest = new AdminService(mockService.Object);
 
-            var result = underTest.GetVolunteersForDate(disasterWithCommitments, new DateTime(2013, 08, 12));
+            var result = underTest.GetVolunteersForDate(disasterWithCommitments, new DateTime(2013, 08, 12), clusterCoordinatorsOnly: false);
 
             Assert.AreEqual(1, result.Count());
         }
@@ -212,7 +212,7 @@ namespace Services.UnitTest
 
             var underTest = new AdminService(mockService.Object);
 
-            var result = underTest.GetVolunteersForDate(disasterWithCommitments, new DateTime(2013, 08, 5));
+            var result = underTest.GetVolunteersForDate(disasterWithCommitments, new DateTime(2013, 08, 5), clusterCoordinatorsOnly: false);
 
             Assert.AreEqual(0, result.Count());
         }
@@ -234,7 +234,7 @@ namespace Services.UnitTest
 
             var underTest = new AdminService(mockData.Object);
 
-            var actual = underTest.GetVolunteersForDate(42, DateTime.Today);
+            var actual = underTest.GetVolunteersForDate(42, DateTime.Today, clusterCoordinatorsOnly: false);
 
             Assert.AreEqual(1, actual.Count());
         }

--- a/crisischeckin/Services.UnitTest/MessageServiceTests.cs
+++ b/crisischeckin/Services.UnitTest/MessageServiceTests.cs
@@ -17,7 +17,7 @@ namespace Services.UnitTest
             var volunteers = new List<Person>();
             volunteers.Add(new Person { Id = 1, Email = "email-1", FirstName = "first", LastName = "last" });
             volunteers.Add(new Person { Id = 2, Email = "email-2", FirstName = "first", LastName = "last" });
-            mockAdminSvc.Setup(x => x.GetVolunteersForDate(It.IsAny<int>(), DateTime.Today)).Returns(volunteers);
+            mockAdminSvc.Setup(x => x.GetVolunteersForDate(It.IsAny<int>(), DateTime.Today, false)).Returns(volunteers);
             var mockMessageCoordinator = new Mock<IMessageCoordinator>();
 
             var expectedMessage = new Message("body", "subject");

--- a/crisischeckin/Services/Interfaces/IAdmin.cs
+++ b/crisischeckin/Services/Interfaces/IAdmin.cs
@@ -7,8 +7,8 @@ namespace Services.Interfaces
     public interface IAdmin
     {
         IEnumerable<Person> GetVolunteers(Disaster disaster);
-        IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date);
-        IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date);
+        IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date, bool clusterCoordinatorsOnly);
+        IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date, bool clusterCoordinatorsOnly);
         IEnumerable<Person> GetVolunteersForDisaster(int disasterId, DateTime? commitmentDate);
     }
 }

--- a/crisischeckin/Services/MessageService.cs
+++ b/crisischeckin/Services/MessageService.cs
@@ -17,7 +17,7 @@ namespace Services
 
         public void SendMessageToDisasterVolunteers(RecipientCriterion recipientCriterion, Message message)
         {
-            var volunteers = _adminSvc.GetVolunteersForDate(recipientCriterion.DisasterId, DateTime.Today);
+            var volunteers = _adminSvc.GetVolunteersForDate(recipientCriterion.DisasterId, DateTime.Today, recipientCriterion.ClusterCoordinatorsOnly);
 
             var messageRecipients = new List<MessageRecipient>();
             foreach (var volunteer in volunteers)

--- a/crisischeckin/Services/RecipientCriterion.cs
+++ b/crisischeckin/Services/RecipientCriterion.cs
@@ -5,10 +5,13 @@ namespace Services
         public int DisasterId { get; private set; }
         public int? ClusterId { get; private set; }
 
-        public RecipientCriterion(int disasterId, int? clusterId = null)
+        public bool ClusterCoordinatorsOnly { get; private set; }
+
+        public RecipientCriterion(int disasterId, int? clusterId = null, bool clusterCoordinatorsOnly = false)
         {
             DisasterId = disasterId;
             ClusterId = clusterId;
+            ClusterCoordinatorsOnly = clusterCoordinatorsOnly;
         }
     }
 }

--- a/crisischeckin/crisicheckinweb/Controllers/VolunteerController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/VolunteerController.cs
@@ -53,7 +53,7 @@ namespace crisicheckinweb.Controllers
                 PopulateSendMessageViewModel(model);
                 return View("CreateMessage", model);
             }
-            var recipientCriterion = new RecipientCriterion(model.DisasterId, model.ClusterId);
+            var recipientCriterion = new RecipientCriterion(model.DisasterId, model.ClusterId, model.ClusterCoordinatorsOnly);
             var message = new Message(model.Subject, model.Message);
             _messageSvc.SendMessageToDisasterVolunteers(recipientCriterion, message);
 

--- a/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
@@ -21,6 +21,8 @@ namespace crisicheckinweb.ViewModels
         public string Subject { get; set; }
         [Required, StringLength(TextMessageLength*4)]
         public string Message { get; set; }
+        [Display(Name="Cluster coordinators only")]
+        public bool ClusterCoordinatorsOnly { get; set; }
 
         public IEnumerable<Cluster> Clusters { get; set; }
     }

--- a/crisischeckin/crisicheckinweb/Views/Volunteer/CreateMessage.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Volunteer/CreateMessage.cshtml
@@ -10,24 +10,27 @@
 {
     @Html.ValidationSummary()
     <fieldset class="col-lg-11">
-        <legend>Send message</legend>
-        <ol>
-            <li>
-                @Html.LabelFor(m => m.Subject, new { htmlAttributes = new { style = "width: 250px;" } })
-                
-                @Html.EditorFor(m => m.Subject, new { htmlAttributes = new { style = "width: 500px;" } })
-            </li>
-            <li>
-                @Html.LabelFor(m => m.Message)
-                @Html.TextAreaFor(m => m.Message, 25, 76, null)
-            </li>
-            <li>
-                @Html.LabelFor(m => m.ClusterId)
-                @Html.DropDownListFor(m => m.ClusterId, new SelectList(Model.Clusters, "Id", "Name", Model.ClusterId), "All Clusters", new { htmlAttributes = new { style = "width: 500px;" } })
-            </li>
-        </ol>
+        @{
+            var width250Attributes = new { htmlAttributes = new { style = "width: 250px;" } };
+            var width500Attributes = new { htmlAttributes = new { style = "width: 500px;" } };
+        }
+
+        <p>@Html.LabelFor(m => m.Subject, width250Attributes)</p>
+        <p>@Html.EditorFor(m => m.Subject, width500Attributes)</p>
+
+        <p>@Html.LabelFor(m => m.ClusterId, width250Attributes)</p>
+        <p>@Html.DropDownListFor(m => m.ClusterId, new SelectList(Model.Clusters, "Id", "Name", Model.ClusterId), "All Clusters", width500Attributes)</p>
+
+        <p>
+            @Html.LabelFor(m => m.ClusterCoordinatorsOnly, width250Attributes)
+            @Html.CheckBoxFor(m => m.ClusterCoordinatorsOnly)
+        </p>
+
+        <p>@Html.LabelFor(m => m.Message, width250Attributes)</p>
+        <p>@Html.TextAreaFor(m => m.Message, 25, 76, null)</p>
+
         @Html.HiddenFor(m => m.DisasterId)
+
         <input type="submit" value="Send" class="btn btn-success" />
-      @*  @Html.SubmitButton("Send");*@
     </fieldset>
 }


### PR DESCRIPTION
Cleans up the send mail UI a bit, and adds a checkbox to send to only Cluster Coordinators.

Let me know about the approach in the AdminService?  Should I add the new method publically to IAdmin instead of doing it conditionally?
