### PR TITLE
Use injected SmtpClient factory instead of default constructor.

### DIFF
--- a/crisischeckin/Services/SmtpMessageSender.cs
+++ b/crisischeckin/Services/SmtpMessageSender.cs
@@ -22,12 +22,8 @@ namespace Services
         public void SendMessage(Message message, IReadOnlyCollection<MessageRecipient> recipients)
         {
 
-            using (var smtpClient = new SmtpClient())
+            using (var smtpClient = _smtpClientFactory())
             {
-#if DEBUG
-                // Emails go to "C:\Users\[USER]\AppData\Roaming" if not Rlease mode
-                smtpClient.PickupDirectoryLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-#endif
                 var fromAddress = CreateAddress(string.Concat(message.Subject, " - Coordinator"), "no-reply@CrisisCheckin.com");
 
                 foreach (var recipient in recipients)

--- a/crisischeckin/crisicheckinweb/App_Start/NinjectWebCommon.cs
+++ b/crisischeckin/crisicheckinweb/App_Start/NinjectWebCommon.cs
@@ -75,7 +75,15 @@ namespace crisicheckinweb.App_Start
             kernel.Bind<IMessageCoordinator>().To<MessageCoordinator>().InRequestScope();
             kernel.Bind<IClusterCoordinatorService>().To<ClusterCoordinatorService>().InRequestScope();
             kernel.Bind<IApiService>().To<ApiService>().InRequestScope();
-            kernel.Bind<Func<SmtpClient>>().ToMethod(c => () => new SmtpClient()).InRequestScope();
+            kernel.Bind<Func<SmtpClient>>()
+                .ToMethod(c => () => new SmtpClient
+                {
+#if DEBUG
+                    // Emails go to "C:\Users\[USER]\AppData\Roaming" if not Release mode
+                    PickupDirectoryLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+#endif
+                })
+                .InRequestScope();
 #if DEBUG
             kernel.Bind<IMessageSender>().To<DebugMessageSender>();
 #else


### PR DESCRIPTION
As discussed in https://github.com/HTBox/crisischeckin/pull/241#issuecomment-74406785
I moved construction and configuration of the SmtpClient to the Ninject
Container registration instead of creating a new SmtpClient in the
SmtpMessageSender.

fixes HTBox/crisischeckin#243
