### PR TITLE
Use the cluster id of the user when fetching the cluster coordinators.

### DIFF
--- a/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
@@ -87,8 +87,10 @@ namespace crisicheckinweb.Controllers
             var commitments = (person != null) ?
                 _volunteerSvc.RetrieveCommitments(person.Id, true) :
                 new List<Commitment>().AsEnumerable();
-            
-            var clusterCoordinators = _clusterCoordinatorService.GetAllCoordinatorsForCluster(1).ToList();
+
+            var clusterCoordinators = (person != null && person.ClusterId.HasValue) ?
+                _clusterCoordinatorService.GetAllCoordinatorsForCluster(person.ClusterId.Value).ToList() :
+                new List<ClusterCoordinator>().AsEnumerable();
 
             var model = new VolunteerViewModel
             {


### PR DESCRIPTION
The cluster coordinators were not shown in the list of commitments when
the user belonged to a cluster other than id 1.

Fixes HTBox/crisischeckin#248