### PR TITLE
Added DisplayName to VolunteerViewModel to generate user friendly errors.

### DIFF
--- a/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Web;
 using Models;
@@ -12,9 +13,13 @@ namespace crisicheckinweb.ViewModels
         public IEnumerable<Commitment> MyCommitments { get; set; }
         public int RemoveCommitmentId { get; set; }
         public int PersonId { get; set; }
+        [DisplayName("Volunteer for Disaster")]
         public int SelectedDisasterId { get; set; }
+        [DisplayName("Start Date")]
         public DateTime SelectedStartDate { get; set; }
+        [DisplayName("End Date")]
         public DateTime SelectedEndDate { get; set; }
+        [DisplayName("Location")]
         public int VolunteerType { get; set; }
         public IEnumerable<VolunteerType> VolunteerTypes { get; set; }
         public Person Person { get; set; }


### PR DESCRIPTION
When not filling in the fields on the volunteer form, error messages for all fields are generated by using the property name (StartDate) instead of a more user friendly text with spaces (Start Date).

Fixes HTBox/crisischeckin#42