### PR TITLE
Bootstrap.js was not included so the 'responsive' menu didn't work.

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/Shared/_Layout.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Shared/_Layout.cshtml
@@ -45,7 +45,7 @@
         @RenderBody()
     </div>
     
-    <script src="http://ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.1.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.1.min.js"></script>
     <script>
         // Fallback to loading jQuery from a local path if the CDN is unavailable
         (window.jQuery || document.write('<script src="/scripts/jquery-2.1.1.min.js"><\/script>'));
@@ -53,6 +53,8 @@
 
     <script type="text/javascript" src="~/scripts/jquery.unobtrusive-ajax.min.js"></script>
     <script type="text/javascript" src="~/scripts/jquery-ui-1.10.4.min.js"></script>
+    <script type="text/javascript" src="~/scripts/bootstrap.min.js"></script>
+
     @RenderSection("scripts", false)
 </body>
 </html>


### PR DESCRIPTION
Added inclusion of bootstrap.min.js so that the responsive menu opens when clicked on.
(also removed protocol from jquery cdn include so that the https version is used when deployed)

Fixes HTBox/crisischeckin#188