### PR TITLE
Added 'Send to checked-in volunteers only' checkbox to Send Message form

### DIFF
--- a/crisischeckin/Services.UnitTest/MessageServiceTests.cs
+++ b/crisischeckin/Services.UnitTest/MessageServiceTests.cs
@@ -17,7 +17,7 @@ namespace Services.UnitTest
             var volunteers = new List<Person>();
             volunteers.Add(new Person { Id = 1, Email = "email-1", FirstName = "first", LastName = "last" });
             volunteers.Add(new Person { Id = 2, Email = "email-2", FirstName = "first", LastName = "last" });
-            mockAdminSvc.Setup(x => x.GetVolunteersForDate(It.IsAny<int>(), DateTime.Today, false)).Returns(volunteers);
+            mockAdminSvc.Setup(x => x.GetVolunteersForDate(It.IsAny<int>(), DateTime.Today, false, false)).Returns(volunteers);
             var mockMessageCoordinator = new Mock<IMessageCoordinator>();
 
             var expectedMessage = new Message("body", "subject");

--- a/crisischeckin/Services/AdminService.cs
+++ b/crisischeckin/Services/AdminService.cs
@@ -8,72 +8,74 @@ namespace Services
 {
     public class AdminService : IAdmin
     {
-        private readonly IDataService dataService;
+        private readonly IDataService _dataService;
 
         public AdminService(IDataService service)
         {
             if (service == null)
                 throw new ArgumentNullException("service", "Service Interface must not be null");
-            this.dataService = service;
+            _dataService = service;
         }
 
-        public IEnumerable<Person> GetVolunteers(Disaster disaster)
+        public IEnumerable<Person> GetVolunteers(Disaster disaster, bool checkedInOnly = false)
         {
             if (disaster == null)
                 throw new ArgumentNullException("disaster", "disaster cannot be null");
 
-            var people = GetPeople(disaster.Id);
+            var people = GetPeople(disaster.Id, checkedInOnly);
 
             if (people == null)
                 throw new NullReferenceException(string.Format("Attempt to get volunteers for disaster ID {0} returned null.", disaster.Id));
             return people.ToList();
         }
 
-        public IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date, bool clusterCoordinatorsOnly)
+        public IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date, bool clusterCoordinatorsOnly, bool checkedInOnly = false)
         {
             if (disaster == null)
                 throw new ArgumentNullException("disaster", "disaster cannot be null");
 
-            return GetVolunteersForDate(disaster.Id, date, clusterCoordinatorsOnly);
+            return GetVolunteersForDate(disaster.Id, date, clusterCoordinatorsOnly, checkedInOnly);
         }
 
-        public IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date, bool clusterCoordinatorsOnly)
+        public IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date, bool clusterCoordinatorsOnly, bool checkedInOnly = false)
         {
             if (disasterId <= 0)
                 throw new ArgumentException("disasterId is invalid.", "disasterId");
 
             var people = clusterCoordinatorsOnly
-                ? GetClusterCoordinatorsForDateQueryable(disasterId, date)
-                : GetVolunteersForDateQueryable(disasterId, date);
+                ? GetClusterCoordinatorsForDateQueryable(disasterId, date, checkedInOnly)
+                : GetVolunteersForDateQueryable(disasterId, date, checkedInOnly);
 
             if (people == null)
                 throw new NullReferenceException(string.Format("Attempt to get volunteers for disaster ID {0} returned null.", disasterId));
             return people.ToList();
         }
 
-        private IQueryable<Person> GetClusterCoordinatorsForDateQueryable(int disasterId, DateTime date)
+        private IQueryable<Person> GetClusterCoordinatorsForDateQueryable(int disasterId, DateTime date, bool checkedInOnly)
         {
             if (disasterId <= 0)
                 throw new ArgumentException("disasterId must be greater than zero", "disasterId");
 
-            var people = from cc in dataService.ClusterCoordinators
+            var people = from cc in _dataService.ClusterCoordinators
                          where cc.DisasterId == disasterId
-                         join c in dataService.Commitments on cc.PersonId equals c.PersonId
+                         join c in _dataService.Commitments on cc.PersonId equals c.PersonId
                          where c.DisasterId == disasterId
+                         where !checkedInOnly || c.PersonIsCheckedIn
                          where date >= c.StartDate && date <= c.EndDate
                          select cc.Person;
 
             return people.Distinct();
         }
 
-        private IQueryable<Person> GetVolunteersForDateQueryable(int disasterId, DateTime date)
+        private IQueryable<Person> GetVolunteersForDateQueryable(int disasterId, DateTime date, bool checkedInOnly)
         {
             if (disasterId <= 0)
                 throw new ArgumentException("disasterId must be greater than zero", "disasterId");
 
-            var people = from p in dataService.Persons
-                         join c in dataService.Commitments on p.Id equals c.PersonId
+            var people = from p in _dataService.Persons
+                         join c in _dataService.Commitments on p.Id equals c.PersonId
                          where c.DisasterId == disasterId
+                         where !checkedInOnly || c.PersonIsCheckedIn
                          where date >= c.StartDate && date <= c.EndDate
                          select p;
             //people.Include(x => x.Cluster);
@@ -81,16 +83,16 @@ namespace Services
             return people.Distinct();
         }
 
-        public IEnumerable<Person> GetVolunteersForDisaster(int disasterId, DateTime? commitmentDate)
+        public IEnumerable<Person> GetVolunteersForDisaster(int disasterId, DateTime? commitmentDate, bool checkedInOnly = false)
         {
             IEnumerable<Person> people;
             if (commitmentDate.HasValue)
             {
-                people = GetVolunteersForDate(disasterId, commitmentDate.Value, clusterCoordinatorsOnly: false);
+                people = GetVolunteersForDate(disasterId, commitmentDate.Value, clusterCoordinatorsOnly: false, checkedInOnly: checkedInOnly);
             }
             else
             {
-                people = GetPeople(disasterId);
+                people = GetPeople(disasterId, checkedInOnly);
             }
 
             if (people == null)
@@ -98,14 +100,15 @@ namespace Services
             return people.ToList();
         }
 
-        private IQueryable<Person> GetPeople(int disasterId)
+        private IQueryable<Person> GetPeople(int disasterId, bool checkedInOnly)
         {
             if (disasterId <= 0)
                 throw new ArgumentException("disasterId is invalid.", "disasterId");
 
-            var people = from p in dataService.Persons
-                         join c in dataService.Commitments on p.Id equals c.PersonId
+            var people = from p in _dataService.Persons
+                         join c in _dataService.Commitments on p.Id equals c.PersonId
                          where c.DisasterId == disasterId
+                         where !checkedInOnly || c.PersonIsCheckedIn
                          select p;
 
             return people.Distinct();

--- a/crisischeckin/Services/Interfaces/IAdmin.cs
+++ b/crisischeckin/Services/Interfaces/IAdmin.cs
@@ -6,9 +6,9 @@ namespace Services.Interfaces
 {
     public interface IAdmin
     {
-        IEnumerable<Person> GetVolunteers(Disaster disaster);
-        IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date, bool clusterCoordinatorsOnly);
-        IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date, bool clusterCoordinatorsOnly);
-        IEnumerable<Person> GetVolunteersForDisaster(int disasterId, DateTime? commitmentDate);
+        IEnumerable<Person> GetVolunteers(Disaster disaster, bool checkedInOnly = false);
+        IEnumerable<Person> GetVolunteersForDate(Disaster disaster, DateTime date, bool clusterCoordinatorsOnly, bool checkedInOnly = false);
+        IEnumerable<Person> GetVolunteersForDate(int disasterId, DateTime date, bool clusterCoordinatorsOnly, bool checkedInOnly = false);
+        IEnumerable<Person> GetVolunteersForDisaster(int disasterId, DateTime? commitmentDate, bool checkedInOnly = false);
     }
 }

--- a/crisischeckin/Services/MessageService.cs
+++ b/crisischeckin/Services/MessageService.cs
@@ -17,7 +17,7 @@ namespace Services
 
         public void SendMessageToDisasterVolunteers(RecipientCriterion recipientCriterion, Message message)
         {
-            var volunteers = _adminSvc.GetVolunteersForDate(recipientCriterion.DisasterId, DateTime.Today, recipientCriterion.ClusterCoordinatorsOnly);
+            var volunteers = _adminSvc.GetVolunteersForDate(recipientCriterion.DisasterId, DateTime.Today, recipientCriterion.ClusterCoordinatorsOnly, recipientCriterion.CheckedInOnly);
 
             var messageRecipients = new List<MessageRecipient>();
             foreach (var volunteer in volunteers)

--- a/crisischeckin/Services/RecipientCriterion.cs
+++ b/crisischeckin/Services/RecipientCriterion.cs
@@ -6,12 +6,14 @@ namespace Services
         public int? ClusterId { get; private set; }
 
         public bool ClusterCoordinatorsOnly { get; private set; }
+        public bool CheckedInOnly { get; private set; }
 
-        public RecipientCriterion(int disasterId, int? clusterId = null, bool clusterCoordinatorsOnly = false)
+        public RecipientCriterion(int disasterId, int? clusterId = null, bool clusterCoordinatorsOnly = false, bool checkedInOnly = false)
         {
             DisasterId = disasterId;
             ClusterId = clusterId;
             ClusterCoordinatorsOnly = clusterCoordinatorsOnly;
+            CheckedInOnly = checkedInOnly;
         }
     }
 }

--- a/crisischeckin/WebProjectTests/VolunteerControllerTests.cs
+++ b/crisischeckin/WebProjectTests/VolunteerControllerTests.cs
@@ -40,7 +40,7 @@ namespace WebProjectTests
             var disaster = new Disaster();
             _disasterSvc.Setup(x => x.Get(disasterId)).Returns(disaster);
             var allVolunteers = new List<Person>();
-            _adminSvc.Setup(x => x.GetVolunteersForDisaster(disaster.Id, null)).Returns(allVolunteers);
+            _adminSvc.Setup(x => x.GetVolunteersForDisaster(disaster.Id, null, false)).Returns(allVolunteers);
 
             var controller = CreateVolunteerController();
             //Act
@@ -66,7 +66,7 @@ namespace WebProjectTests
             var disaster = new Disaster();
             _disasterSvc.Setup(x => x.Get(disasterId)).Returns(disaster);
             var filteredVolunteers = new List<Person>();
-            _adminSvc.Setup(x => x.GetVolunteersForDisaster(disaster.Id, filteredDateTime)).Returns(filteredVolunteers);
+            _adminSvc.Setup(x => x.GetVolunteersForDisaster(disaster.Id, filteredDateTime, false)).Returns(filteredVolunteers);
 
             var controller = CreateVolunteerController();
             //Act

--- a/crisischeckin/crisicheckinweb/Controllers/VolunteerController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/VolunteerController.cs
@@ -52,7 +52,7 @@ namespace crisicheckinweb.Controllers
                 PopulateSendMessageViewModel(model);
                 return View("CreateMessage", model);
             }
-            var recipientCriterion = new RecipientCriterion(model.DisasterId, model.ClusterId, model.ClusterCoordinatorsOnly);
+            var recipientCriterion = new RecipientCriterion(model.DisasterId, model.ClusterId, model.ClusterCoordinatorsOnly, model.CheckedInOnly);
             var message = new Message(model.Subject, model.Message);
             _messageSvc.SendMessageToDisasterVolunteers(recipientCriterion, message);
 

--- a/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
@@ -23,6 +23,8 @@ namespace crisicheckinweb.ViewModels
         public string Message { get; set; }
         [Display(Name="Cluster coordinators only")]
         public bool ClusterCoordinatorsOnly { get; set; }
+        [Display(Name = "Send to checked-in volunteers only")]
+        public bool CheckedInOnly { get; set; }
 
         public IEnumerable<Cluster> Clusters { get; set; }
     }

--- a/crisischeckin/crisicheckinweb/Views/Volunteer/CreateMessage.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Volunteer/CreateMessage.cshtml
@@ -25,6 +25,10 @@
         @Html.CheckBoxFor(m => m.ClusterCoordinatorsOnly)
         @Html.LabelFor(m => m.ClusterCoordinatorsOnly)
     </div>
+    <div class="form-group">
+        @Html.CheckBoxFor(m => m.CheckedInOnly)
+        @Html.LabelFor(m => m.CheckedInOnly)
+    </div>
     <div class="form-group required">
         @Html.LabelFor(m => m.Message)
         @Html.TextAreaFor(m => m.Message, 25, 76, new {@class = "form-control"})


### PR DESCRIPTION
All public methods on the AdminService to retrieve volunteers now have an optional checkedInOnly parameter (defaults to false) for filtering.

Fixes HTBox/crisischeckin#10
