### PR TITLE
Changed error message and moved date comparisons for model validation.

### DIFF
--- a/crisischeckin/Services.UnitTest/DisasterServiceTest.cs
+++ b/crisischeckin/Services.UnitTest/DisasterServiceTest.cs
@@ -54,6 +54,15 @@ namespace Services.UnitTest
         }
 
         [TestMethod]
+        [ExpectedException(typeof (ArgumentException))]
+        public void AssignToVolunteer_StartDateInThePast()
+        {
+            var startDate = DateTime.Today.AddDays(-10);
+            var endDate = startDate.AddDays(1);
+            _disasterService.AssignToVolunteer(0, 0, startDate, endDate, 1);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void AssignToVolunteer_StartDateIsWithinExistingCommitment()
         {
@@ -144,12 +153,14 @@ namespace Services.UnitTest
             _mockDataService.Setup(s => s.AddCommitment(It.IsAny<Commitment>()))
                 .Callback<Commitment>(commitment => createdCommitment = commitment);
 
+            var commitmentDate = DateTime.Today.AddDays(1);
+
             var commitments = new List<Commitment>
             {
                 new Commitment
                 {
-                    StartDate = new DateTime(2013, 5, 8),
-                    EndDate = new DateTime(2013, 5, 8),
+                    StartDate = commitmentDate,
+                    EndDate = commitmentDate,
                     DisasterId = 2
                 }
             };
@@ -158,8 +169,8 @@ namespace Services.UnitTest
             _mockDataService.Setup(s => s.Commitments).Returns(commitments.AsQueryable());
             _mockDataService.Setup(s => s.Disasters).Returns(disasters.AsQueryable());
 
-            var startDate = new DateTime(2013, 5, 7);
-            var endDate = new DateTime(2013, 5, 7);
+            var startDate = commitmentDate.AddDays(-1);
+            var endDate = commitmentDate.AddDays(-1);
             _disasterService.AssignToVolunteer(0, 0, startDate, endDate, 1);
 
             Assert.IsNotNull(createdCommitment);
@@ -174,12 +185,14 @@ namespace Services.UnitTest
             _mockDataService.Setup(s => s.AddCommitment(It.IsAny<Commitment>()))
                 .Callback<Commitment>(commitment => createdCommitment = commitment);
 
+            var commitmentDate = DateTime.Today;
+
             var commitments = new List<Commitment>
             {
                 new Commitment
                 {
-                    StartDate = new DateTime(2013, 5, 6),
-                    EndDate = new DateTime(2013, 5, 6),
+                    StartDate = commitmentDate,
+                    EndDate = commitmentDate,
                     DisasterId = 2
                 }
             };
@@ -188,8 +201,8 @@ namespace Services.UnitTest
             _mockDataService.Setup(s => s.Commitments).Returns(commitments.AsQueryable());
             _mockDataService.Setup(s => s.Disasters).Returns(disasters.AsQueryable());
 
-            var startDate = new DateTime(2013, 5, 7);
-            var endDate = new DateTime(2013, 5, 7);
+            var startDate = commitmentDate.AddDays(1);
+            var endDate = commitmentDate.AddDays(1);
             _disasterService.AssignToVolunteer(0, 0, startDate, endDate, 1);
 
             Assert.IsNotNull(createdCommitment);
@@ -256,8 +269,8 @@ namespace Services.UnitTest
 
             const int personId = 5;
             const int disasterId = 10;
-            var startDate = new DateTime(2013, 01, 01);
-            var endDate = new DateTime(2013, 02, 01);
+            var startDate = DateTime.Today;
+            var endDate = startDate.AddDays(1);
             _disasterService.AssignToVolunteer(disasterId, personId, startDate, endDate, 1);
 
             Assert.IsNotNull(createdCommitment);
@@ -287,8 +300,8 @@ namespace Services.UnitTest
 
             const int personId = 5;
             const int disasterId = 2;
-            var startDate = new DateTime(2013, 01, 02);
-            var endDate = new DateTime(2013, 01, 03);
+            var startDate = DateTime.Today;
+            var endDate = startDate.AddDays(1);
 
             Commitment createdCommitment = null;
             _mockDataService.Setup(s => s.AddCommitment(It.IsAny<Commitment>()))

--- a/crisischeckin/Services/DisasterService.cs
+++ b/crisischeckin/Services/DisasterService.cs
@@ -22,7 +22,13 @@ namespace Services
         public void AssignToVolunteer(int disasterId, int personId, DateTime startDate, DateTime endDate, int volunteerType)
         {
             if (DateTime.Compare(endDate, startDate) < 0)
-                throw new ArgumentException("endDate cannot be earlier than startDate");
+            {
+                throw new ArgumentException("Please enter a end date that is greater than or equal to the start date.");
+            }
+            if (DateTime.Compare(DateTime.Today, startDate) > 0)
+            {
+                throw new ArgumentException("Please enter a start date that is greater than or equal to today's date.");
+            }
 
 			// check if the start and end date falls within an existing commitment
 			// disregard any disasters that are inactive

--- a/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
@@ -52,11 +52,6 @@ namespace crisicheckinweb.Controllers
 
             try
             {
-                if (DateTime.Compare(DateTime.Today, model.SelectedStartDate) > 0)
-                {
-                    throw new ArgumentException("Please enter a start date that is greater than today's date.");
-                }
-
                 var person = _volunteerSvc.FindByUserId(_webSecurity.CurrentUserId);
                 if (person == null)
                 {

--- a/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
@@ -6,7 +6,7 @@ using Models;
 
 namespace crisicheckinweb.ViewModels
 {
-    public class VolunteerViewModel : IValidatableObject
+    public class VolunteerViewModel
     {
         public IEnumerable<Disaster> Disasters { get; set; }
         public IEnumerable<Commitment> MyCommitments { get; set; }
@@ -23,14 +23,5 @@ namespace crisicheckinweb.ViewModels
         public IEnumerable<VolunteerType> VolunteerTypes { get; set; }
         public Person Person { get; set; }
         public IEnumerable<ClusterCoordinator> ClusterCoordinators { get; set; }
-
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            if (DateTime.Compare(DateTime.Today, SelectedStartDate) > 0)
-            {
-                yield return new ValidationResult("Please enter a start date that is greater than or equal to today's date.", new [] { "SelectedStartDate" });
-            }
-        }
     }
 }

--- a/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
@@ -31,10 +31,6 @@ namespace crisicheckinweb.ViewModels
             {
                 yield return new ValidationResult("Please enter a start date that is greater than or equal to today's date.", new [] { "SelectedStartDate" });
             }
-            if (DateTime.Compare(SelectedStartDate, SelectedEndDate) > 0)
-            {
-                yield return new ValidationResult("Please enter a end date that is greater than or equal to the start date.", new [] { "SelectedEndDate" });
-            }
         }
     }
 }

--- a/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/VolunteerViewModel.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Web;
+using System.ComponentModel.DataAnnotations;
 using Models;
 
 namespace crisicheckinweb.ViewModels
 {
-    public class VolunteerViewModel
+    public class VolunteerViewModel : IValidatableObject
     {
         public IEnumerable<Disaster> Disasters { get; set; }
         public IEnumerable<Commitment> MyCommitments { get; set; }
@@ -23,6 +22,19 @@ namespace crisicheckinweb.ViewModels
         public int VolunteerType { get; set; }
         public IEnumerable<VolunteerType> VolunteerTypes { get; set; }
         public Person Person { get; set; }
-        public IEnumerable<ClusterCoordinator> ClusterCoordinators { get; set; } 
+        public IEnumerable<ClusterCoordinator> ClusterCoordinators { get; set; }
+
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (DateTime.Compare(DateTime.Today, SelectedStartDate) > 0)
+            {
+                yield return new ValidationResult("Please enter a start date that is greater than or equal to today's date.", new [] { "SelectedStartDate" });
+            }
+            if (DateTime.Compare(SelectedStartDate, SelectedEndDate) > 0)
+            {
+                yield return new ValidationResult("Please enter a end date that is greater than or equal to the start date.", new [] { "SelectedEndDate" });
+            }
+        }
     }
 }


### PR DESCRIPTION
Changed the error message when the selected start date is before today to be more precise and moved this comparison to the viewmodel. By implementing the IValidatableObject the throwing new ArgumentException can be removed from the controller.

Fixes HTBox/crisischeckin#179