### PR TITLE
Filter the persons on disaster when assigning a cluster coordinator.

### DIFF
--- a/crisischeckin/Services.UnitTest/ClusterCoordinatorService/GetClusterCoordinatorTests.cs
+++ b/crisischeckin/Services.UnitTest/ClusterCoordinatorService/GetClusterCoordinatorTests.cs
@@ -20,6 +20,7 @@ namespace Services.UnitTest.ClusterCoordinatorService
         private Person _person2;
         private Cluster _cluster2;
         private Disaster _disaster2;
+        private Person _person3;
 
         [TestInitialize]
         public void Init()
@@ -36,6 +37,7 @@ namespace Services.UnitTest.ClusterCoordinatorService
 
             _person1 = new Person { Id = 3, FirstName = "John", LastName = "Doe" };
             _person2 = new Person { Id = 4, FirstName = "Richard", LastName = "Roe" };
+            _person3 = new Person { Id = 5, FirstName = "Little", LastName = "Toe" };
 
             _dataService.Setup(x => x.Disasters).Returns(new EnumerableQuery<Disaster>(new[]
             {
@@ -50,7 +52,14 @@ namespace Services.UnitTest.ClusterCoordinatorService
             _dataService.Setup(x => x.Persons).Returns(new EnumerableQuery<Person>(new[]
             {
                 _person1,
-                _person2
+                _person2,
+                _person3
+            }));
+            _dataService.Setup(x => x.Commitments).Returns(new EnumerableQuery<Commitment>(new[]
+            {
+                new Commitment { DisasterId = _disaster1.Id, PersonId = _person1.Id },
+                new Commitment { DisasterId = _disaster1.Id, PersonId = _person2.Id },
+                new Commitment { DisasterId = _disaster2.Id, PersonId = _person3.Id }
             }));
             _clusterCoordinatorService = new Services.ClusterCoordinatorService(_dataService.Object);
         }
@@ -119,6 +128,8 @@ namespace Services.UnitTest.ClusterCoordinatorService
             const string personErrorMsg = "Could not find person with the ID of ";
             var firstPerson = allPersonsForDisplay.FirstOrDefault(x => x.Id == _person1.Id);
             Assert.IsNotNull(firstPerson, personErrorMsg + _person1.Id);
+            var thirdPerson = allPersonsForDisplay.FirstOrDefault(x => x.Id == _person3.Id);
+            Assert.IsNull(thirdPerson, "Third person has not volunteerd for disaster " + _disaster1.Id);
 
         }
 

--- a/crisischeckin/Services/ClusterCoordinatorService.cs
+++ b/crisischeckin/Services/ClusterCoordinatorService.cs
@@ -195,7 +195,7 @@ namespace Services
                               ClusterId = x.ClusterId
                           }).ToList();
 
-            var persons = GetAllPersonDataForDisplay();
+            var persons = GetAllPersonDataForDisasterForDisplay(disasterId);
             allPersonsForDisplay = persons;
 
             return result.Select(x => new ClusterCoordinator
@@ -207,19 +207,25 @@ namespace Services
                 }).ToList();
         }
 
-        private IList<Person> GetAllPersonDataForDisplay()
+        private IList<Person> GetAllPersonDataForDisasterForDisplay(int disasterId)
         {
-            var result = _dataService.Persons.Select(p => new
-                {
-                    Id = p.Id,
-                    FirstName = p.FirstName,
-                    LastName = p.LastName
-                }).ToList();
+            var result = (from p in _dataService.Persons
+                          join cm in _dataService.Commitments
+                           on p.Id equals cm.PersonId
+                          where cm.DisasterId == disasterId
+                          select new
+                            {
+                                Id = p.Id,
+                                FirstName = p.FirstName,
+                                LastName = p.LastName,
+                                ClusterId = p.ClusterId
+                            }).ToList();
             return result.Select(p => new Person
                 {
                     Id = p.Id,
                     FirstName = p.FirstName,
-                    LastName = p.LastName
+                    LastName = p.LastName,
+                    ClusterId = p.ClusterId
                 }).ToList();
         }
     }


### PR DESCRIPTION
For now the persons are only filtered by disaster (as filtering by selected cluster would need more complex javascript code for client filtering or for making extra ajax requests to fetch the filtered people based on the selected cluster).

Fixes HTBox/crisischeckin#259