### PR TITLE
Fixed validation for User name when registering.

### DIFF
--- a/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
@@ -7,6 +7,8 @@ namespace crisicheckinweb.ViewModels
 {
     public class RegisterModel
     {
+        private string _userName;
+
         [Required]
         [Display(Name = "First Name")]
         public string FirstName { get; set; }
@@ -27,9 +29,7 @@ namespace crisicheckinweb.ViewModels
         [Required]
         [StringLength(30, ErrorMessage = "The {0} must be between {2} and {1} characters long.", MinimumLength = 3)]
         [Display(Name = "User name")]
-        private string userName;
-        public string UserName { get { return userName; } set { userName = value.Trim(); } }
-      
+        public string UserName { get { return _userName; } set { _userName = value.Trim(); } }
 
         [Required]
         [DataType(DataType.Password)]

--- a/crisischeckin/crisicheckinweb/scripts/App/accountRegister.js
+++ b/crisischeckin/crisicheckinweb/scripts/App/accountRegister.js
@@ -10,7 +10,7 @@
   });
 
   function checkUsernameExists(userName, parent) {
-    if (userName == "") {
+    if (!userName || userName.trim().length < 3) {
       $(parent).removeClass("success").removeClass("failure");
       if ($(parent).next().hasClass("feedbackHelper")) $(parent).next().remove();
       return;


### PR DESCRIPTION
Delayed the check for availability of a username until three characters are typed to prevent a message that the username is available when only one or two characters are filled in.
The DataAnnotations on the viewmodel to check for the length of username were on the private field instead of the public property so they were never used.

Fixes HTBox/crisischeckin#177