### PR TITLE
Moved Password complexity check to separate class; added check username != password.

### DIFF
--- a/crisischeckin/WebProjectTests/HomeControllerTests.cs
+++ b/crisischeckin/WebProjectTests/HomeControllerTests.cs
@@ -27,7 +27,13 @@ namespace WebProjectTests
             var controller = new HomeController(disaster.Object, volunteer.Object, webSecurity.Object, clusterCoordinator.Object, volType.Object);
 
             volunteer.Setup(x => x.FindByUserId(It.IsAny<int>())).Returns(new Person());
-            webSecurity.SetupGet(x => x.CurrentUserId).Returns(10);
+
+            disaster.Setup(x => x.AssignToVolunteer(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<int>())).Throws(new ArgumentException(""));
 
             // Act
             var viewModel = new VolunteerViewModel { SelectedStartDate = DateTime.Today.AddDays(-1) };

--- a/crisischeckin/WebProjectTests/Infrastructure/PasswordComplexityTests.cs
+++ b/crisischeckin/WebProjectTests/Infrastructure/PasswordComplexityTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using crisicheckinweb.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Resources;
+
+namespace WebProjectTests.Infrastructure
+{
+    [TestClass]
+    public class PasswordComplexityTests
+    {
+        [TestMethod]
+        public void ValidWhenPasswordIsEqualToUsername()
+        {
+            // Act
+            string errorMessage;
+            bool valid = PasswordComplexity.IsValid("psswrd", "user01", out errorMessage);
+
+            // Assert
+            Assert.IsTrue(valid);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestMethod]
+        public void InvalidWhenPasswordIsEqualToUsername()
+        {
+            // Act
+            string errorMessage;
+            bool valid = PasswordComplexity.IsValid("user01", "user01", out errorMessage);
+
+            // Assert
+            Assert.IsFalse(valid);
+            Assert.AreEqual(DefaultErrorMessages.InvalidPasswordEqualToUserName, errorMessage);
+        }
+    }
+}

--- a/crisischeckin/WebProjectTests/WebProjectTests.csproj
+++ b/crisischeckin/WebProjectTests/WebProjectTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="DisasterControllerTests.cs" />
     <Compile Include="HomeControllerTests.cs" />
     <Compile Include="Infrastructure\Attributes\BasicPasswordAttributeTests.cs" />
+    <Compile Include="Infrastructure\PasswordComplexityTests.cs" />
     <Compile Include="Mother.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VolunteerControllerTests.cs" />

--- a/crisischeckin/crisicheckinweb/App_GlobalResources/DefaultErrorMessages.Designer.cs
+++ b/crisischeckin/crisicheckinweb/App_GlobalResources/DefaultErrorMessages.Designer.cs
@@ -61,6 +61,15 @@ namespace Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid password. Your password cannot be equal to your username..
+        /// </summary>
+        public static string InvalidPasswordEqualToUserName {
+            get {
+                return ResourceManager.GetString("InvalidPasswordEqualToUserName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please enter a password that is 6-20 characters long..
         /// </summary>
         public static string InvalidPasswordFormat {

--- a/crisischeckin/crisicheckinweb/App_GlobalResources/DefaultErrorMessages.resx
+++ b/crisischeckin/crisicheckinweb/App_GlobalResources/DefaultErrorMessages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidPasswordEqualToUserName" xml:space="preserve">
+    <value>Invalid password. Your password cannot be equal to your username.</value>
+  </data>
   <data name="InvalidPasswordFormat" xml:space="preserve">
     <value>Please enter a password that is 6-20 characters long.</value>
   </data>

--- a/crisischeckin/crisicheckinweb/Infrastructure/Attributes/BasicPasswordAttribute.cs
+++ b/crisischeckin/crisicheckinweb/Infrastructure/Attributes/BasicPasswordAttribute.cs
@@ -1,31 +1,27 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Resources;
 
 namespace crisicheckinweb.Infrastructure.Attributes
 {
-    public class BasicPasswordAttribute : RegularExpressionAttribute
+    public class BasicPasswordAttribute : ValidationAttribute
     {
         public BasicPasswordAttribute()
-            : base(@"^[^\s]{6,20}$")
         {
             ErrorMessage = DefaultErrorMessages.InvalidPasswordFormat;
         }
 
         public override bool IsValid(object value)
         {
-            if (!base.IsValid(value)) return false;
-
-            var commonWords = new[] { "password", "pass", "ht" };
             var stringValue = (string)value;
 
             // Some fields are not required
             if (string.IsNullOrWhiteSpace(stringValue)) return true;
 
-            if (commonWords.Any(w => stringValue.IndexOf(w, StringComparison.InvariantCultureIgnoreCase) >= 0))
+            string errorMessage;
+            if (!PasswordComplexity.IsValid(stringValue, out errorMessage))
             {
-                ErrorMessage = DefaultErrorMessages.InvalidPasswordGenericUsed;
+                ErrorMessage = errorMessage;
                 return false;
             }
 

--- a/crisischeckin/crisicheckinweb/Infrastructure/PasswordComplexity.cs
+++ b/crisischeckin/crisicheckinweb/Infrastructure/PasswordComplexity.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Resources;
+
+namespace crisicheckinweb.Infrastructure
+{
+    public class PasswordComplexity
+    {
+        public static bool IsValid(string password, out string errorMessage)
+        {
+            return IsValid(password, null, out errorMessage);
+        }
+
+        public static bool IsValid(string password, string userName, out string errorMessage)
+        {
+            // Check for password length
+            if (!Regex.IsMatch(password, @"^[^\s]{6,20}$"))
+            {
+                errorMessage = DefaultErrorMessages.InvalidPasswordFormat;
+                return false;
+            }
+
+            // Check for equality to username
+            if (userName != null && String.Compare(password, userName, StringComparison.InvariantCultureIgnoreCase) == 0)
+            {
+                errorMessage = DefaultErrorMessages.InvalidPasswordEqualToUserName;
+                return false;
+            }
+
+            // Check for common words
+            var commonWords = new[] { "password", "pass", "ht" };
+            if (commonWords.Any(w => password.IndexOf(w, StringComparison.InvariantCultureIgnoreCase) >= 0))
+            {
+                errorMessage = DefaultErrorMessages.InvalidPasswordGenericUsed;
+                return false;
+            }
+
+            // By the current rules the password is safe enough to be used.
+            errorMessage = null;
+            return true;
+        }
+    }
+}

--- a/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
+++ b/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Helpers\MenuExtensions.cs" />
     <Compile Include="Infrastructure\Attributes\BasicPasswordAttribute.cs" />
     <Compile Include="Infrastructure\Attributes\ExpireContentAttribute.cs" />
+    <Compile Include="Infrastructure\PasswordComplexity.cs" />
     <Compile Include="NavigationRoutes\INavigationRouteFilter.cs" />
     <Compile Include="NavigationRoutes\NamedRoute.cs" />
     <Compile Include="NavigationRoutes\NavigationExtensions.cs" />


### PR DESCRIPTION
By moving the password complexity check to a separate class it can be used by both the BasicPasswordAttribute and the AccountController.
Extra password checks can be added to the PasswordComplexity class when needed.

Fixes HTBox/crisischeckin#45