### PR TITLE
List by Disaster page renders calendar incorrectly because of bundling.

### DIFF
--- a/crisischeckin/crisicheckinweb/App_Start/BundleConfig.cs
+++ b/crisischeckin/crisicheckinweb/App_Start/BundleConfig.cs
@@ -7,11 +7,13 @@ namespace crisicheckinweb
         public static void RegisterBundles(BundleCollection bundles)
         {
             bundles.Add(new StyleBundle("~/Content/css").Include(
-                "~/Content/themes/base/jquery.ui.all.css",
                 "~/Content/bootstrap.css",
                 "~/Content/bootstrap-theme.css",
                 "~/Content/htbox-theme.css",
                 "~/Content/site.css"));
+
+            bundles.Add(new StyleBundle("~/Content/themes/base/jqueryui").Include(
+                "~/Content/themes/base/jquery.ui.all.css"));
 
             bundles.Add(new ScriptBundle("~/bundles/libs").Include(
                 "~/Scripts/jquery-2.1.1.js",

--- a/crisischeckin/crisicheckinweb/Views/Shared/_Layout.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Shared/_Layout.cshtml
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Crisis Checkin</title>
     @Styles.Render("~/Content/css")
+    @Styles.Render("~/Content/themes/base/jqueryui")
 
     @RenderSection("styles", false)
 


### PR DESCRIPTION
This happens only in release mode.

Solved by creating a separate bundle for jquery ui theme.