### PR TITLE
Implemented Account activation functionality.

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/Account/ConfirmAccount.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Account/ConfirmAccount.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+  ViewBag.Title = "Account activation was succesful";
+}
+
+<div class="col-lg-6 col-sm-12 col-xs-12 col-md-6">
+  <h3>@ViewBag.Title</h3>
+
+  <div>
+    You can now @Html.ActionLink("login", "Login") using the credentials you provided during registration.
+  </div>
+
+</div>

--- a/crisischeckin/crisicheckinweb/Views/Account/RegistrationSuccessful.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Account/RegistrationSuccessful.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+    ViewBag.Title = "Registration was successful";
+}
+
+<div class="col-lg-6 col-sm-12 col-xs-12 col-md-6">
+    <h3>@ViewBag.Title</h3>
+
+    <div>
+        You will receive an email with a link to activate your account shortly.
+    </div>
+
+</div>

--- a/crisischeckin/crisicheckinweb/Wrappers/IWebSecurityWrapper.cs
+++ b/crisischeckin/crisicheckinweb/Wrappers/IWebSecurityWrapper.cs
@@ -8,7 +8,9 @@
 
         int GetUserId(string userName);
 
-        int CreateUser(string userName, string password, string[] roleNames);
+        string CreateUser(string userName, string password, string[] roleNames, out int userId);
+
+        bool ConfirmAccount(string token);
 
         bool ChangePassword(string userName, string currentPassword, string newPassword);
 

--- a/crisischeckin/crisicheckinweb/Wrappers/UserNotActivatedException.cs
+++ b/crisischeckin/crisicheckinweb/Wrappers/UserNotActivatedException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace crisicheckinweb.Wrappers
+{
+    public class UserNotActivatedException : Exception
+    {
+        public UserNotActivatedException()
+        {
+        }
+
+        public UserNotActivatedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
+++ b/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
@@ -242,6 +242,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\UpgradeVolunteerRoleViewModel.cs" />
     <Compile Include="ViewModels\VolunteerViewModel.cs" />
+    <Compile Include="Wrappers\UserNotActivatedException.cs" />
     <Compile Include="Wrappers\WebSecurityWrapper.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -400,6 +401,8 @@
     <Content Include="Views\Account\PasswordResetRequested.cshtml" />
     <Content Include="Views\Account\ResetPassword.cshtml" />
     <Content Include="Views\Account\PasswordResetCompleted.cshtml" />
+    <Content Include="Views\Account\ConfirmAccount.cshtml" />
+    <Content Include="Views\Account\RegistrationSuccessful.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="App_GlobalResources\DefaultErrorMessages.resx">


### PR DESCRIPTION
Email with confirmation link is sent after a user registration. 
The user cannot login before the link is clicked (or copied in the browser) and the account is activated.

Fixes HTbox/crisischeckin#46