### PR TITLE
Backbutton after unassigning coordinator resulted in wrong redirect.

### DIFF
--- a/crisischeckin/Services/ClusterCoordinatorService.cs
+++ b/crisischeckin/Services/ClusterCoordinatorService.cs
@@ -148,7 +148,12 @@ namespace Services
                               FirstName = p.FirstName,
                               LastName = p.LastName,
                               ClusterName = cl.Name
-                          }).Single();
+                          }).FirstOrDefault();
+
+            if (result == null)
+            {
+                return null;
+            }
 
             return new ClusterCoordinator
             {

--- a/crisischeckin/crisicheckinweb/Controllers/ClusterCoordinatorController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/ClusterCoordinatorController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
-using System.Web.Routing;
 using crisicheckinweb.ViewModels;
 using Models;
 using Services.Interfaces;
@@ -12,16 +11,13 @@ namespace crisicheckinweb.Controllers
     {
         readonly ICluster _cluster;
         readonly IClusterCoordinatorService _clusterCoordinatorService;
-        readonly IDataService _dataService;
         readonly IDisaster _disaster;
 
         public ClusterCoordinatorController(
             IDisaster disaster,
             ICluster cluster,
-            IClusterCoordinatorService clusterCoordinatorService,
-            IDataService dataService)
+            IClusterCoordinatorService clusterCoordinatorService)
         {
-            _dataService = dataService;
             _disaster = disaster;
             _cluster = cluster;
             _clusterCoordinatorService = clusterCoordinatorService;
@@ -81,9 +77,14 @@ namespace crisicheckinweb.Controllers
         }
 
         [HttpGet]
-        public ActionResult ConfirmUnassignCoordinator(int id)
+        public ActionResult ConfirmUnassignCoordinator(int id, int disasterId)
         {
             var clusterCoordinator = _clusterCoordinatorService.GetCoordinatorForUnassign(id);
+            if (clusterCoordinator == null)
+            {
+                return RedirectToAction("Index", new { id = disasterId });
+            }
+
             var vm = new UnassignClusterCoordinatorViewModel
                      {
                          DisasterId = clusterCoordinator.DisasterId,
@@ -99,7 +100,7 @@ namespace crisicheckinweb.Controllers
         {
             var clusterCoordinator = _clusterCoordinatorService.GetCoordinatorFullyLoaded(id);
             if (null == clusterCoordinator)
-                return RedirectToAction("Index", "Home");
+                return RedirectToAction("Index");
             _clusterCoordinatorService.UnassignClusterCoordinator(clusterCoordinator);
             return RedirectToAction("Index", new { id = clusterCoordinator.DisasterId });
         }

--- a/crisischeckin/crisicheckinweb/Views/ClusterCoordinator/AssignCoordinator.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/ClusterCoordinator/AssignCoordinator.cshtml
@@ -14,7 +14,7 @@
                 {
                     <div class="cluster-coordinator">
                         @coordinator.Name
-                        <a class="close glyphicon glyphicon-remove" href="@Url.Action("ConfirmUnassignCoordinator", new {id=@coordinator.Id})"></a>
+                        <a class="close glyphicon glyphicon-remove" href="@Url.Action("ConfirmUnassignCoordinator", new {id=@coordinator.Id, disasterId=@Model.DisasterId})"></a>
                     </div>
                 }
             </td>


### PR DESCRIPTION
By passing the current disasterId as a parameter for the action we can redirect to the disaster page.
Also did some minor code cleanup.

Fixes HTBox/crisischeckin#195