### PR TITLE
Added Length Constraints Free-Form Inputs

### DIFF
--- a/crisischeckin/Models/Cluster.cs
+++ b/crisischeckin/Models/Cluster.cs
@@ -1,8 +1,10 @@
-﻿namespace Models
+﻿using System.ComponentModel.DataAnnotations;
+namespace Models
 {
     public class Cluster
     {
         public int Id { get; set; }
+        [StringLength(50)]
         public string Name { get; set; }
 
     }

--- a/crisischeckin/Models/ClusterCoordinatorLog.cs
+++ b/crisischeckin/Models/ClusterCoordinatorLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Models
 {
@@ -8,10 +9,13 @@ namespace Models
         public DateTime TimeStampUtc { get; set; }
         public ClusterCoordinatorEvents Event { get; set; }
         public int PersonId { get; set; }
+        [StringLength(61)] //30 first name + space + 30 last name
         public string PersonName { get; set; }
         public int DisasterId { get; set; }
+        [StringLength(50)]
         public string DisasterName { get; set; }
         public int ClusterId { get; set; }
+        [StringLength(50)]
         public string ClusterName { get; set; }
     }
 }

--- a/crisischeckin/Models/CrisisCheckin.cs
+++ b/crisischeckin/Models/CrisisCheckin.cs
@@ -29,6 +29,7 @@ namespace Models
         {
             base.OnModelCreating(modelBuilder);
             modelBuilder.Conventions.Remove<PluralizingTableNameConvention>();
+            modelBuilder.Conventions.Remove<StringLengthAttributeConvention>();
         }
     }
 }

--- a/crisischeckin/Models/Disaster.cs
+++ b/crisischeckin/Models/Disaster.cs
@@ -1,8 +1,11 @@
-﻿namespace Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Models
 {
     public class Disaster
     {
         public int Id { get; set; }
+        [StringLength(50)]
         public string Name { get; set; }
         public bool IsActive { get; set; }
     }

--- a/crisischeckin/Models/Person.cs
+++ b/crisischeckin/Models/Person.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
 namespace Models
 {
     public class Person
@@ -6,8 +8,11 @@ namespace Models
         public int Id { get; set; }         // Used for identity in Person table.
         public int? UserId { get; set; }     // Used for membership provider and eventually an OAuth implementation
         public int? ClusterId { get; set; }
+        [StringLength(30)]
         public string FirstName { get; set; }
+        [StringLength(30)]
         public string LastName { get; set; }
+        [RegularExpression(@"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}", ErrorMessage = "Invalid email format.")]
         public string Email { get; set; }
         public string PhoneNumber { get; set; }
 

--- a/crisischeckin/Models/User.cs
+++ b/crisischeckin/Models/User.cs
@@ -1,8 +1,11 @@
-﻿namespace Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Models
 {
     public class User
     {
         public int Id { get; set; }
+        [StringLength(30, ErrorMessage = "The {0} must be between {2} and {1} characters long.", MinimumLength = 3)]
         public string UserName { get; set; }
 
     }

--- a/crisischeckin/crisicheckinweb/ViewModels/ClusterCoordinatorViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/ClusterCoordinatorViewModel.cs
@@ -1,7 +1,10 @@
-﻿namespace crisicheckinweb.ViewModels
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace crisicheckinweb.ViewModels
 {
     public class ClusterCoordinatorViewModel
     {
+        [StringLength(61)]
         public string Name { get; set; }
         public int Id { get; set; }
     }

--- a/crisischeckin/crisicheckinweb/ViewModels/ClusterViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/ClusterViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace crisicheckinweb.ViewModels
 {
     public class ClusterViewModel
     {
+        [StringLength(50)]
         public string Name { get; set; }
         public List<ClusterCoordinatorViewModel> Coordinators { get; set; }
     }

--- a/crisischeckin/crisicheckinweb/ViewModels/DisasterViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/DisasterViewModel.cs
@@ -10,7 +10,7 @@ namespace crisicheckinweb.ViewModels
         public int Id { get; set; }
 
         [Required]
-        [StringLength(100)]
+        [StringLength(50)]
         [DisplayName("Disaster name")]
         public string Name { get; set; }
 

--- a/crisischeckin/crisicheckinweb/ViewModels/ForgotPasswordViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/ForgotPasswordViewModel.cs
@@ -7,6 +7,7 @@ namespace crisicheckinweb.ViewModels
     {
         [Required]
         [Display(Name = "Username or Email")]
+        [StringLength(254)] //Email address max length
         public string UserNameOrEmail { get; set; }
     }
 }

--- a/crisischeckin/crisicheckinweb/ViewModels/LoginModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/LoginModel.cs
@@ -6,6 +6,7 @@ namespace crisicheckinweb.ViewModels
     {
         [Required]
         [Display(Name = "Username or Email")]
+        [StringLength(254)] //Email address max length
         public string UserNameOrEmail { get; set; }
 
         [Required]

--- a/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
@@ -29,7 +29,7 @@ namespace crisicheckinweb.ViewModels
         [Required]
         [StringLength(30, ErrorMessage = "The {0} must be between {2} and {1} characters long.", MinimumLength = 3)]
         [Display(Name = "User name")]
-        public string UserName { get { return _userName; } set { _userName = value.Trim(); } }
+        public string UserName { get { return _userName; } set { _userName = value != null ? value.Trim() : value; } }
 
         [Required]
         [DataType(DataType.Password)]

--- a/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/RegisterModel.cs
@@ -11,9 +11,11 @@ namespace crisicheckinweb.ViewModels
 
         [Required]
         [Display(Name = "First Name")]
+        [StringLength(30)]
         public string FirstName { get; set; }
 
         [Required]
+        [StringLength(30)]
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 

--- a/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/SendMessageToAllVolunteersByDisasterViewModel.cs
@@ -13,6 +13,8 @@ namespace crisicheckinweb.ViewModels
 
         [Required]
         public int DisasterId { get; set; }
+        [StringLength(50)]
+        [Display(Name = "Disaster")]
         public string DisasterName { get; set; }
         [Display(Name="Cluster")]
         public int? ClusterId { get; set; }

--- a/crisischeckin/crisicheckinweb/ViewModels/UnassignClusterCoordinatorViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/UnassignClusterCoordinatorViewModel.cs
@@ -1,10 +1,20 @@
-﻿namespace crisicheckinweb.ViewModels
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace crisicheckinweb.ViewModels
 {
     public class UnassignClusterCoordinatorViewModel
     {
         public int DisasterId { get; set; }
         public int CoordinatorId { get; set; }
+
+        [Required]
+        [StringLength(61)]//30 first name + space + 30 last name
+        [Display(Name = "Coordinator")]
         public string CoordinatorName { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        [Display(Name = "Cluster")]
         public string ClusterName { get; set; }
     }
 }


### PR DESCRIPTION
In addition to solving issue #59 this will also cover some other free-form entry fields. Names for humans allow for 30 character first names and 30 character last names. Names for things (i.e. disasters, clusters, etc) are 50 characters. 

In order to maintain the flexibility on the DB side for future expansion, I removed the StringLengthAttributeConvention from the DBContext.