### PR TITLE
Updated mail behavior for staging and development #286

### DIFF
--- a/crisischeckin/AcceptanceTests/AcceptanceTests.csproj
+++ b/crisischeckin/AcceptanceTests/AcceptanceTests.csproj
@@ -34,6 +34,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Breeze.Sharp">
       <HintPath>..\packages\Breeze.Sharp.0.6.0.2\lib\portable-net45+wp80+win\Breeze.Sharp.dll</HintPath>

--- a/crisischeckin/Common/Common.csproj
+++ b/crisischeckin/Common/Common.csproj
@@ -29,6 +29,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/crisischeckin/Common/Constants.cs
+++ b/crisischeckin/Common/Constants.cs
@@ -14,5 +14,9 @@
         public const string DefaultTestUserName = "TestUser";
         public const string DefaultTestUserPassword = "test";
 
+        //Environments
+        public const string Staging = "staging";
+        public const string Development = "development";
+        public const string Production = "production";
     }
 }

--- a/crisischeckin/CrisisCheckinWeb.sln
+++ b/crisischeckin/CrisisCheckinWeb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22310.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "crisicheckinweb", "crisicheckinweb\crisicheckinweb.csproj", "{212DEAC4-D307-4480-94CE-2951E22B13F8}"
 EndProject
@@ -43,6 +43,12 @@ Global
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x86 = Release|x86
+		Staging|Any CPU = Staging|Any CPU
+		Staging|ARM = Staging|ARM
+		Staging|iPhone = Staging|iPhone
+		Staging|iPhoneSimulator = Staging|iPhoneSimulator
+		Staging|Mixed Platforms = Staging|Mixed Platforms
+		Staging|x86 = Staging|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
@@ -77,6 +83,14 @@ Global
 		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Release|x86.ActiveCfg = Release|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{212DEAC4-D307-4480-94CE-2951E22B13F8}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -109,6 +123,14 @@ Global
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Release|x86.ActiveCfg = Release|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{29F2C62B-0F89-44E9-8EDB-6C4F7987647A}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -141,6 +163,14 @@ Global
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{D7A71984-2CC2-4DA7-9346-D697FDBF15B4}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -173,6 +203,14 @@ Global
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Release|x86.ActiveCfg = Release|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{3FD36CF5-7D79-4505-A0BB-12E35A613D88}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -205,6 +243,14 @@ Global
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Release|x86.ActiveCfg = Release|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{F6C6C990-7B39-457F-95A1-D22EC67F4A79}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -237,6 +283,14 @@ Global
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Release|x86.ActiveCfg = Release|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{85D45B1B-D669-4370-8D5C-60D2350C5544}.Staging|x86.ActiveCfg = Staging|Any CPU
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Ad-Hoc|Any CPU.ActiveCfg = Release|Any CPU
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Ad-Hoc|Any CPU.Build.0 = Release|Any CPU
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Ad-Hoc|ARM.ActiveCfg = Release|Any CPU
@@ -269,6 +323,14 @@ Global
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{12248512-C6DE-4B1B-8560-D8A09911A300}.Release|x86.ActiveCfg = Release|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|Any CPU.ActiveCfg = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|Any CPU.Build.0 = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|ARM.ActiveCfg = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|iPhone.ActiveCfg = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|iPhoneSimulator.ActiveCfg = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|Mixed Platforms.ActiveCfg = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|Mixed Platforms.Build.0 = Staging|Any CPU
+		{12248512-C6DE-4B1B-8560-D8A09911A300}.Staging|x86.ActiveCfg = Staging|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/crisischeckin/Models/Models.csproj
+++ b/crisischeckin/Models/Models.csproj
@@ -31,6 +31,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/crisischeckin/Services.UnitTest/Services.UnitTest.csproj
+++ b/crisischeckin/Services.UnitTest/Services.UnitTest.csproj
@@ -36,6 +36,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.2.1408.717, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/crisischeckin/Services/Services.csproj
+++ b/crisischeckin/Services/Services.csproj
@@ -50,6 +50,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -94,10 +95,15 @@
     <Compile Include="Interfaces\IVolunteerService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmtpMessageSender.cs" />
+    <Compile Include="SubjectEnrichmentService.cs" />
     <Compile Include="VolunteerService.cs" />
     <Compile Include="VolunteerTypeService.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{85d45b1b-d669-4370-8d5c-60d2350c5544}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Models\Models.csproj">
       <Project>{3fd36cf5-7d79-4505-a0bb-12e35a613d88}</Project>
       <Name>Models</Name>

--- a/crisischeckin/Services/Services.csproj
+++ b/crisischeckin/Services/Services.csproj
@@ -31,6 +31,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/crisischeckin/Services/SmtpMessageSender.cs
+++ b/crisischeckin/Services/SmtpMessageSender.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Net.Mail;
+using Common;
 using Services.Interfaces;
 
 namespace Services
@@ -29,7 +31,7 @@ namespace Services
                     var recipientAddress = new MailAddress(recipient.EmailAddress, recipient.Name);
                     var mailMessage = new MailMessage(fromAddress, recipientAddress)
                     {
-                        Subject = message.Subject,
+                        Subject = SubjectEnrichmentService.Enrich(message.Subject),
                         IsBodyHtml = true,
                         Body = message.Body
                     };
@@ -37,5 +39,6 @@ namespace Services
                 }
             }
         }
+
     }
 }

--- a/crisischeckin/Services/SubjectEnrichmentService.cs
+++ b/crisischeckin/Services/SubjectEnrichmentService.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Common;
+
+namespace Services
+{
+    internal class SubjectEnrichmentService
+    {
+        /// <summary>
+        /// If we are not in production, prepend the email subject with [STAGING] or [DEVELOPMENT], depending
+        /// on the environment.
+        /// </summary>
+        internal static string Enrich(string subject)
+        {
+            var environment = ConfigurationManager.AppSettings["environment"];
+
+            if (environment == Constants.Production)
+            {
+                return subject;               
+            }
+
+            return string.Format("[{0}] {1}", environment.ToUpper(), subject);
+        }
+    }
+}

--- a/crisischeckin/WebProjectTests/WebProjectTests.csproj
+++ b/crisischeckin/WebProjectTests/WebProjectTests.csproj
@@ -36,6 +36,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\Staging\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/crisischeckin/crisicheckinweb/App_Start/NinjectWebCommon.cs
+++ b/crisischeckin/crisicheckinweb/App_Start/NinjectWebCommon.cs
@@ -72,8 +72,6 @@ namespace crisicheckinweb.App_Start
             kernel.Bind<IWebSecurityWrapper>().To<WebSecurityWrapper>().InRequestScope();
             kernel.Bind<IVolunteerTypeService>().To<VolunteerTypesService>().InRequestScope();
             kernel.Bind<IMessageService>().To<MessageService>().InRequestScope();
-            // Is this still necessary?
-            // kernel.Bind<IMessageSender>().To<DebugMessageSender>();
             kernel.Bind<IMessageSender>().To<SmtpMessageSender>().InRequestScope();
             kernel.Bind<MailAddress>()
                 .ToConstant(new MailAddress("no-reply@crisischeckin.com", "CrisisCheckin"))

--- a/crisischeckin/crisicheckinweb/Properties/PublishProfiles/LocalStaging.pubxml
+++ b/crisischeckin/crisicheckinweb/Properties/PublishProfiles/LocalStaging.pubxml
@@ -6,16 +6,16 @@ by editing this MSBuild file. In order to learn more about this please visit htt
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <WebPublishMethod>FileSystem</WebPublishMethod>
-    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedBuildConfiguration>Staging</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
-    <ExcludeApp_Data>True</ExcludeApp_Data>
-    <publishUrl>C:\inetpub\wwwroot\crisischeckinweb</publishUrl>
-    <DeleteExistingFiles>True</DeleteExistingFiles>
     <PrecompileBeforePublish>True</PrecompileBeforePublish>
     <EnableUpdateable>True</EnableUpdateable>
     <DebugSymbols>False</DebugSymbols>
     <WDPMergeOption>DonotMerge</WDPMergeOption>
+    <ExcludeApp_Data>True</ExcludeApp_Data>
+    <publishUrl>C:\inetpub\wwwroot\crisischeckinweb</publishUrl>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
   </PropertyGroup>
 </Project>

--- a/crisischeckin/crisicheckinweb/Web.Release.config
+++ b/crisischeckin/crisicheckinweb/Web.Release.config
@@ -24,6 +24,8 @@
       </rules>
     </rewrite>
   </system.webServer>
+
+  <!-- The actual email credentials are handled via azure configuration. -->
   <system.net xdt:Transform="Replace">
     <mailSettings>
       <smtp deliveryMethod="Network">

--- a/crisischeckin/crisicheckinweb/Web.Release.config
+++ b/crisischeckin/crisicheckinweb/Web.Release.config
@@ -53,4 +53,8 @@
       password="{ADD PASSWORD HERE}"
       />
   </elmah>
+
+  <appSettings>
+    <add key="environment" value="production"  xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+  </appSettings>  
 </configuration>

--- a/crisischeckin/crisicheckinweb/Web.Staging.config
+++ b/crisischeckin/crisicheckinweb/Web.Staging.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--<system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+  </system.web>-->
+
+  <appSettings>
+    <add key="environment" value="staging"  xdt:Transform="Replace" xdt:Locator="Match(key)"/>
+  </appSettings>
+</configuration>

--- a/crisischeckin/crisicheckinweb/Web.Staging.config
+++ b/crisischeckin/crisicheckinweb/Web.Staging.config
@@ -3,9 +3,9 @@
 <!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <!--<system.web>
+  <system.web>
     <compilation xdt:Transform="RemoveAttributes(debug)" />
-  </system.web>-->
+  </system.web>
 
   <system.webServer>
     <rewrite>
@@ -14,7 +14,8 @@
       </rules>
     </rewrite>
   </system.webServer>
-  
+
+  <!-- The actual email credentials are handled via azure configuration. -->
   <system.net xdt:Transform="Replace">
     <mailSettings>
       <smtp deliveryMethod="Network">

--- a/crisischeckin/crisicheckinweb/Web.Staging.config
+++ b/crisischeckin/crisicheckinweb/Web.Staging.config
@@ -7,6 +7,28 @@
     <compilation xdt:Transform="RemoveAttributes(debug)" />
   </system.web>-->
 
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="Force HTTPS" enabled="true" xdt:Transform="SetAttributes" xdt:Locator="Match(name)" />
+      </rules>
+    </rewrite>
+  </system.webServer>
+  
+  <system.net xdt:Transform="Replace">
+    <mailSettings>
+      <smtp deliveryMethod="Network">
+        <network
+          defaultCredentials="false"
+          enableSsl="true"
+          host="smtp.gmail.com"
+          port="587"
+          userName="username"
+          password="password" />
+      </smtp>
+    </mailSettings>
+  </system.net>
+     
   <appSettings>
     <add key="environment" value="staging"  xdt:Transform="Replace" xdt:Locator="Match(key)"/>
   </appSettings>

--- a/crisischeckin/crisicheckinweb/Web.config
+++ b/crisischeckin/crisicheckinweb/Web.config
@@ -30,6 +30,7 @@
     <add key="elmah.mvc.allowedRoles" value="*" />
     <add key="elmah.mvc.allowedUsers" value="*" />
     <add key="elmah.mvc.route" value="elmah" />
+    <add key="environment" value="development" />
   </appSettings>
   <system.net>
     <mailSettings>

--- a/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
+++ b/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
@@ -406,6 +406,7 @@
     <Content Include="Views\Account\RegistrationSuccessful.cshtml" />
     <None Include="Web.Staging.config">
       <DependentUpon>Web.config</DependentUpon>
+      <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
+++ b/crisischeckin/crisicheckinweb/crisicheckinweb.csproj
@@ -328,6 +328,7 @@
     <Content Include="Content\bootstrap-theme.css.map" />
     <Content Include="Content\bootstrap.css.map" />
     <None Include="Properties\PublishProfiles\LocalRelease.pubxml" />
+    <None Include="Properties\PublishProfiles\LocalStaging.pubxml" />
     <None Include="scripts\amplify-vsdoc.js" />
     <Content Include="scripts\amplify.js" />
     <Content Include="scripts\amplify.min.js" />
@@ -403,6 +404,9 @@
     <Content Include="Views\Account\PasswordResetCompleted.cshtml" />
     <Content Include="Views\Account\ConfirmAccount.cshtml" />
     <Content Include="Views\Account\RegistrationSuccessful.cshtml" />
+    <None Include="Web.Staging.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="App_GlobalResources\DefaultErrorMessages.resx">
@@ -460,6 +464,15 @@
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Staging|AnyCPU'">
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
This pull request centers around:
 - **New web.config transforms and publish settings for Staging**.
 - Introduced of a new **environment app setting**, and some constants to help prevent magic strings. Which seemed to be the convention in this project. 
 - **SubjectEnrichmentService**, which prepends environment tags to non-production mail subjects. 

Notes:
I didn't want to make assumptions about how configuration should be handled so I just did this with ConfigurationManager to start. It's not too hard to go back and add a facade for testing purposes, etc. 

For this initial approach, I did have to add System.Configuration to Services. I also referenced Common since I added a few constants and needed to use them. I wasn't sure why that was not already referenced. Let me know if I should handle that some other way.

This resolves #286