### PR TITLE
Added cache-control header to Cluster List page so it's always right

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/Cluster/List.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Cluster/List.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewBag.Title = "List";
+    Response.Headers["Cache-Control"] = "no-cache, max-age=0, must-revalidate, no-store";
 }
 
 <h2>List Of Clusters</h2>


### PR DESCRIPTION
Fixes issue #401.

Tested in Firefox 31, Chrome 47 and IE8.  In any browser that does show a page after a cluster is deleted and the Back button is clicked, the page now re-retrieves the most up-to-date list of clusters from the server instead of showing the now-obsolete list from the browser cache.  This prevents the user from subsequently trying to re-delete the phantom cluster.
