### PR TITLE
added a step in the HomeController to also remove a person as a Clust…

### DIFF
--- a/crisischeckin/Services/DataService.cs
+++ b/crisischeckin/Services/DataService.cs
@@ -120,6 +120,15 @@ namespace Services
             return result;
         }
 
+        public void RemoveClusterCoordinator(int personId, int clusterId, int disasterId)
+        {
+            var clusterCoordinator = context.ClusterCoordinators.SingleOrDefault(
+                x => x.PersonId == personId && x.ClusterId == clusterId && x.DisasterId == disasterId);
+            if (clusterCoordinator == null) return;
+            context.ClusterCoordinators.Remove(clusterCoordinator);
+            context.SaveChanges();
+        }
+
         public void AddDisaster(Disaster newDisaster)
         {
             context.Disasters.Add(newDisaster);

--- a/crisischeckin/Services/DisasterService.cs
+++ b/crisischeckin/Services/DisasterService.cs
@@ -75,6 +75,11 @@ namespace Services
             return _dataService.Disasters.Where(d => d.Id.Equals(disasterId)).Select(d => d.Name).FirstOrDefault();
         }
 
+        public void RemoveClusterCoordinator(int personId, int clusterId, int disasterId)
+        {
+            _dataService.RemoveClusterCoordinator(personId, clusterId, disasterId);
+        }
+
         public void Create(Disaster disaster)
         {
             if (disaster == null) throw new ArgumentNullException("disaster");

--- a/crisischeckin/Services/Interfaces/IDataService.cs
+++ b/crisischeckin/Services/Interfaces/IDataService.cs
@@ -33,5 +33,6 @@ namespace Services.Interfaces
         void AppendClusterCoordinatorLogEntry(ClusterCoordinatorLogEntry clusterCoordinatorLogEntry);
         void RemoveClusterCoordinator(ClusterCoordinator clusterCoordinator);
         Commitment UpdateCommitment(Commitment updatedCommitment);
+        void RemoveClusterCoordinator(int personId, int clusterId, int disasterId);
     }
 }

--- a/crisischeckin/Services/Interfaces/IDisaster.cs
+++ b/crisischeckin/Services/Interfaces/IDisaster.cs
@@ -18,5 +18,6 @@ namespace Services.Interfaces
         IEnumerable<Disaster> GetActiveList();
         IEnumerable<Disaster> GetList();
         string GetName(int disasterId);
+        void RemoveClusterCoordinator(int currentUserId, int clusterId, int disasterId);
     }
 }

--- a/crisischeckin/WebProjectTests/HomeControllerTests.cs
+++ b/crisischeckin/WebProjectTests/HomeControllerTests.cs
@@ -120,7 +120,7 @@ namespace WebProjectTests
         public void RemoveCommitmentById_Valid_RedirectsToHome()
         {
             // Arrange
-            var commitments = new List<Commitment>() { new Commitment() { Id = 7, PersonId = 13}};
+            var commitments = new List<Commitment>() { new Commitment() { Id = 7, PersonId = 13, ClusterId = 1, DisasterId = 1}};
 
             _volunteerService.Setup(service => service.FindByUserId(It.IsAny<int>())).Returns(new Person() { Id = 13 });
             _volunteerService.Setup(service => service.RetrieveCommitments(13, true)).Returns(commitments.AsQueryable());

--- a/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/HomeController.cs
@@ -216,12 +216,16 @@ namespace crisicheckinweb.Controllers
                 var person = _volunteerSvc.FindByUserId(_webSecurity.CurrentUserId);
                 var commitments = _volunteerSvc.RetrieveCommitments(person.Id, true).AsEnumerable();
 
-                if (commitments.FirstOrDefault(c => c.Id == model.RemoveCommitmentId) == null)
+
+                var commitment = commitments.FirstOrDefault(c => c.Id == model.RemoveCommitmentId);
+                if (commitment == null)
                 {
                     throw new ArgumentException("Commitment supplied is not yours.");
                 }
 
+                _disasterSvc.RemoveClusterCoordinator(_webSecurity.CurrentUserId, commitment.ClusterId.Value, commitment.DisasterId);
                 _disasterSvc.RemoveCommitmentById(model.RemoveCommitmentId);
+                
 
                 return Redirect("/Home");
             }


### PR DESCRIPTION
…er Coordinator when they are removing themselves from a Disaster.  #406 

When a person removes themselves from a Disaster I added a step to also remove them as a cluster coordinator.
This addresses the issue at the root of the problem buy preventing the data from being in an invalid state.  That is - having a ClusterCoordinator row exist for a person that does not have a matching row in Commitments.