### PR TITLE
modified the delete cluster action so that it redirects to the list a…

### DIFF
--- a/crisischeckin/crisicheckinweb/Controllers/ClusterController.cs
+++ b/crisischeckin/crisicheckinweb/Controllers/ClusterController.cs
@@ -41,7 +41,7 @@ namespace crisicheckinweb.Controllers
                     else
                         _clusterSvc.Update(cluster);
 
-                    return View("List", _clusterSvc.GetList().Select(CreateViewModel));
+                    return RedirectToAction("List");
                 }
                 else
                 {
@@ -67,7 +67,7 @@ namespace crisicheckinweb.Controllers
             Cluster removeCluster = _clusterSvc.Get(cluster.Id);
             _clusterSvc.Remove(removeCluster);
 
-            return View("List", _clusterSvc.GetList().Select(CreateViewModel));
+            return RedirectToAction("List");
         }
 
         // GET: Clusters/


### PR DESCRIPTION
…ction in order to prevent browser-back issues.  #385


This was resolved by Redirecting back to the List action instead of returning a View from the Delete action.  There was a similar issue with Creating a cluster that I also fixed.