### PR TITLE
The volunteer homepage will now show the Organization Name in the "Co…

### DIFF
--- a/crisischeckin/Services/VolunteerService.cs
+++ b/crisischeckin/Services/VolunteerService.cs
@@ -114,7 +114,7 @@ namespace Services
 
         public Person FindByUserId(int userId)
         {
-            return ourService.Persons.SingleOrDefault(p => p.UserId == userId);
+            return ourService.Persons.Include(p => p.Organization).SingleOrDefault(p => p.UserId == userId);
         }
 
         public Person GetPersonDetailsForChangeContactInfo(int userId)

--- a/crisischeckin/crisicheckinweb/Views/Home/Index.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Home/Index.cshtml
@@ -19,6 +19,11 @@
               <dl class="dl-horizontal">
                   <dt>Disaster: </dt>
                   <dd>@commitmentForToday.Disaster.Name</dd>
+                  @if(Model.Person.Organization != null)
+                  {
+                      <dt>Organization: </dt>
+                      <dd>@Model.Person.Organization.OrganizationName</dd>
+                  }
                   <dt>Location: </dt>
                   <dd>@commitmentForToday.VolunteerType.Name</dd>
                   <dt>Cluster: </dt>


### PR DESCRIPTION
Hi...

This covers the functionality requested on issue #474. Note I only specify an organization if there actually is one attached to the volunteer - if not, the entire line is removed (ie the label as well).

It occurs to me that now would be the perfect time for me to investigate the unit testing strategy that has been employed on this project, and include myself a controller test for this work. I'll have a look at that tomorrow - it's 00:30 local time here at the moment, so I'm off to bed...

Martin
