### PR TITLE
Don't show an empty dropdown on Cluster Coordinator Allocation

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/ClusterCoordinator/Index.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/ClusterCoordinator/Index.cshtml
@@ -25,7 +25,14 @@
         </div>
         <div class="form-group">
             @Html.LabelFor(m => m.AvailablePeople, "Available People: ")
-            @Html.DropDownListFor(m => m.SelectedPersonId, new SelectList(Model.AvailablePeople, "Id", "FullName", Model.SelectedPersonId), "-- Choose One --", new { @class = "form-control" })
+            @if (Model.AvailablePeople.Any())
+            {
+                @Html.DropDownListFor(m => m.SelectedPersonId, new SelectList(Model.AvailablePeople, "Id", "FullName", Model.SelectedPersonId), "-- Choose One --", new {@class = "form-control"})
+            }
+            else
+            {
+                <span>No people available.</span>
+            }
         </div>
 
         <input class="btn btn-black" id="AddButton" type="submit" value="Assign Coordinator" />


### PR DESCRIPTION
When allocating cluster coordinators, it was felt that the ui was confusing when there was no person available. 

In those circumstances, I now show a simple statement that noone is available instead of showing the (allegedly) confusing drop down...