### PR TITLE
Issue #606 - "View CheckIns" link doesn't work prior to logging in

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/Account/Login.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Account/Login.cshtml
@@ -2,7 +2,7 @@
 
 @{
   ViewBag.Title = "Log in to existing account...";
-  Layout = "/Views/Shared/_VolunteerLayout.cshtml";
+  Layout = "/Views/Shared/_LoginLayout.cshtml";
 }
 
 

--- a/crisischeckin/crisicheckinweb/Views/Shared/_LoginLayout.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Shared/_LoginLayout.cshtml
@@ -1,0 +1,24 @@
+﻿@using System.Web.Optimization
+@{
+    Layout = "/Views/Shared/_Layout.cshtml";
+}
+<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+    <div class="container">
+        <div class="navbar-header">
+            <a class="navbar-brand" href="/">Crisis Check-In</a>
+        </div>
+    </div>
+</div>
+
+
+<div class="container">
+    @RenderBody()
+</div>
+
+@section scripts {
+    @RenderSection("scripts", required: false)
+}
+
+@section styles {
+    @RenderSection("styles", required: false)
+}


### PR DESCRIPTION
Added new layout page for login.  This layout page contains a navbar that only has the CrisisCheckin Logo.