### PR TITLE
Cleaned up Navbar

### DIFF
--- a/crisischeckin/crisicheckinweb/Views/Shared/_AdminLayout.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Shared/_AdminLayout.cshtml
@@ -17,9 +17,9 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                @Html.MenuItem("Home (Disaster List)", "List", "Disaster")
-                @Html.MenuItem("View Checkins", "ListbyDisaster", "Volunteer")
-                @Html.MenuItem("View Data", "ListResourceCheckinsbyDisaster", "Volunteer")
+                @Html.MenuItem("Disasters", "List", "Disaster")
+                @Html.MenuItem("Checkins", "ListbyDisaster", "Volunteer")
+                @Html.MenuItem("Field Data", "ListResourceCheckinsbyDisaster", "Volunteer")
                 @Html.MenuItem("Requests", "Index", "Requests")
                 @Html.MenuItem("Resources", "Index", "Resources")
             </ul>

--- a/crisischeckin/crisicheckinweb/Views/Shared/_VolunteerLayout.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Shared/_VolunteerLayout.cshtml
@@ -15,9 +15,9 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                @Html.MenuItem("View Checkins", "ListbyDisaster", "Volunteer")
-                @Html.MenuItem("View Data", "ListResourceCheckinsbyDisaster", "Volunteer")
-                @Html.MenuItem("View Requests", "VolunteerRequestIndex", "Requests")
+                @Html.MenuItem("Checkins", "ListbyDisaster", "Volunteer")
+                @Html.MenuItem("Field Data", "ListResourceCheckinsbyDisaster", "Volunteer")
+                @Html.MenuItem("Requests", "VolunteerRequestIndex", "Requests")
             </ul>
             @Html.Partial("_LoginStatus")
         </div><!--/.nav-collapse -->

--- a/crisischeckin/crisicheckinweb/Views/Volunteer/ListByDisaster.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Volunteer/ListByDisaster.cshtml
@@ -1,7 +1,14 @@
 ﻿@model crisicheckinweb.ViewModels.ListByDisasterViewModel
 @{
     ViewBag.Title = "List Checkins";
-    Layout = "~/Views/Shared/_VolunteerLayout.cshtml";
+    if (User.IsInRole("Admin"))
+    {
+        Layout = "~/Views/Shared/_AdminLayout.cshtml";
+    }
+    else
+    {
+        Layout = "~/Views/Shared/_VolunteerLayout.cshtml";
+    }
 }
 
 <h2>@ViewBag.Title</h2>

--- a/crisischeckin/crisicheckinweb/Views/Volunteer/ListResourceCheckinsByDisaster.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Volunteer/ListResourceCheckinsByDisaster.cshtml
@@ -1,8 +1,14 @@
 ﻿@model crisicheckinweb.ViewModels.ListByDisasterViewModel
 @{
     ViewBag.Title = "List Field Data";
-    Layout = "~/Views/Shared/_VolunteerLayout.cshtml";
+    if (User.IsInRole("Admin"))
+    {
+        Layout = "~/Views/Shared/_AdminLayout.cshtml";
+    } else {
+        Layout = "~/Views/Shared/_VolunteerLayout.cshtml";
+    }
 }
+
 
 <h2>@ViewBag.Title</h2>
 @using (Ajax.BeginForm("FilterResourceCheckins", "Volunteer", new AjaxOptions() { UpdateTargetId = "results" }))


### PR DESCRIPTION
Both the Admin and Volunteer UIs shared the Field Reported Data and Checkins pages.  However, both these pages used _VolunteerLayout.cshtml. Therefore, when an Admin clicked links to either of those pages in the NavBar, _VolunteerLayout.cshtml was loaded and not _AdminLayout.cshtml.  The result was that the NavBar would always change to what the Volunteer would see. 

By adding some logic to check whether the user had the Admin role in the Field Reported Data and Checkins pages, the appropriate layout pages for both volunteers and admins are loaded.

I also removed 'View' in the NavBar links.  In my opinion, it is obvious that when you click "Checkins" in the NavBar, you are going to see the Checkins. In addition, the word 'View' in front of each link was beginning to take up too much space in the NavBar, especially for Admins.