### PR TITLE
Adding 'add new organization link' to volunteer homepage.

### DIFF
--- a/crisischeckin/crisicheckinweb/ViewModels/NewOrganizationViewModel.cs
+++ b/crisischeckin/crisicheckinweb/ViewModels/NewOrganizationViewModel.cs
@@ -20,6 +20,7 @@ namespace crisicheckinweb.ViewModels
 
         [Required]
         [MaxLength(50)]
+        [Display(Name ="Organization Name")]
         public string OrganizationName { get; set; }
 
         public Address Address { get; set; }

--- a/crisischeckin/crisicheckinweb/Views/Home/Index.cshtml
+++ b/crisischeckin/crisicheckinweb/Views/Home/Index.cshtml
@@ -234,6 +234,7 @@ else
     </table>
 }
 
+<a class="btn btn-success" href="@Url.Action("RegisterNewOrganization", "Organization")">Register new organization</a>
 
 @section scripts
 {


### PR DESCRIPTION
Fixes #695.

Button located on volunteer homepage following discussion found on [https://github.com/HTBox/crisischeckin/pull/537](url)