### PR TITLE
Fixing markdown for "step" headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ The point is that we will need to start building more of a profile for volunteer
 Installation on a Mac
 ====================
 Since this project is an asp.net project and it is necessary to use visual studio. That being said this is one solution for developers using Macs to contribute to this project. This is also a solution for developers starting who do not already have visual studio installed on their computer.
-####Step 1:
+#### Step 1:
 Create a fast dev environment to have visual studio. One solution to this is using Microsoft Azure, for this you have to have a Microsoft account (Hotmail or Outlook). Once you are logged into Azure follow these steps.
-######a.
+###### Step 1a.
 Select new from the lower left-hand corner. Select the virtual machine option and then select from gallery.
 ![Imgur](http://i.imgur.com/Nxa6490.png)
-######b.
+###### Step 1b.
 Now from the gallery options choose the visual studio on the right hand side. Suggest selecting "Visual Studio Community 2015 with Azure SDK 2.7" or the most updated version. Now continue through the steps to set up the name of your virtual machine, user name and password.
 ![Imgur](http://i.imgur.com/jhbVyFN.png)
-######c.
+###### Step 1c.
 Now download the Microsoft Remote Desktop app (from the App store) to be able to access your virtual machine.
-######d.
+###### Step 1d.
 Back on the azure website you have to connect to your virtual machine. This will download a Remote Desktop Program. If you have trouble with this take the information and put it into the Remote Desktop App after pressing new. For your username it may be just your username but it might be domain/username and then your password.
 ![Imgur](http://i.imgur.com/IglP8Wi.png)
 
-####Step 2:
+#### Step 2:
 Now in the virtual machine it is now suggested to download a GitHub desktop app. Clone your forked repo and start contributing.


### PR DESCRIPTION
markdown requires a space after the hashmarks.  This fixes the rendering to actually be headers.  Also added "Step1" prefix to "a.", "b.", etc, subheaders so they made more sense in the page flow.